### PR TITLE
Refactor Types and Fix Memory Safety Issues

### DIFF
--- a/src/backend/fyra/src/ir/Use.cpp
+++ b/src/backend/fyra/src/ir/Use.cpp
@@ -8,15 +8,24 @@ Use::Use(User* u, Value* v) : user(u), v(nullptr) {
 }
 
 Use::~Use() {
-    set(nullptr);
+    // Break the link to the currently used value.
+    if (v) {
+        v->removeUse(*this);
+        v = nullptr;
+    }
 }
 
 void Use::set(Value* new_v) {
     if (v == new_v) return;
+
+    // Remove from the old value's use list.
     if (v) {
         v->removeUse(*this);
     }
+
     v = new_v;
+
+    // Add to the new value's use list.
     if (v) {
         v->addUse(*this);
     }

--- a/src/backend/fyra/src/ir/Value.cpp
+++ b/src/backend/fyra/src/ir/Value.cpp
@@ -7,10 +7,10 @@ namespace ir {
 
 Value::~Value() {
     // Break connections to all users before this value is destroyed.
-    // We iterate over a copy because u->set(nullptr) will call removeUse,
-    // which modifies use_list.
-    auto current_uses = use_list;
-    for (Use* u : current_uses) {
+    // Use a while loop with front() to safely handle modifications to use_list
+    // during iteration, as u->set(nullptr) will call removeUse on this value.
+    while (!use_list.empty()) {
+        Use* u = use_list.front();
         u->set(nullptr);
     }
 }

--- a/src/backend/types.hh
+++ b/src/backend/types.hh
@@ -909,7 +909,7 @@ public:
     }
     
     // Create union type
-    TypePtr createUnionType(const std::vector<TypePtr>& types) {
+    TypePtr createUnionType(const std::vector<TypePtr>& types, const std::vector<std::string>& names = {}) {
         if (types.empty()) {
             return NIL_TYPE;
         }
@@ -919,6 +919,13 @@ public:
         
         UnionType unionType;
         unionType.types = types;
+        if (names.empty()) {
+            for (const auto& t : types) {
+                unionType.variantNames.push_back(t->toString());
+            }
+        } else {
+            unionType.variantNames = names;
+        }
         
         return std::make_shared<Type>(TypeTag::Union, unionType);
     }

--- a/src/backend/types.hh
+++ b/src/backend/types.hh
@@ -930,6 +930,25 @@ public:
         return std::make_shared<Type>(TypeTag::Union, unionType);
     }
 
+    // Create sum type (discriminated union)
+    TypePtr createSumType(const std::vector<TypePtr>& variants, const std::vector<std::string>& names = {}) {
+        if (variants.empty()) {
+            return NIL_TYPE;
+        }
+
+        SumType sumType;
+        sumType.variants = variants;
+        if (names.empty()) {
+            for (const auto& t : variants) {
+                sumType.variantNames.push_back(t->toString());
+            }
+        } else {
+            sumType.variantNames = names;
+        }
+
+        return std::make_shared<Type>(TypeTag::Sum, sumType);
+    }
+
     // Create union value with specific variant
     ValuePtr createUnionValue(TypePtr unionType, size_t variantIndex, ValuePtr variantValue) {
         if (!unionType || unionType->tag != TypeTag::Union) {

--- a/src/backend/value.hh
+++ b/src/backend/value.hh
@@ -173,7 +173,8 @@ enum class TypeTag {
     Module,
     Frame,
     Trait,
-    TraitObject
+    TraitObject,
+    Refined
 };
 
 // Forward declaration for ClosureValue factory method with proper TypePtr
@@ -303,11 +304,13 @@ struct UserDefinedType
 struct SumType
 {
     std::vector<TypePtr> variants;
+    std::vector<std::string> variantNames;
 };
 
 struct UnionType
 {
     std::vector<TypePtr> types;
+    std::vector<std::string> variantNames;
 };
 
 struct ErrorUnionType
@@ -315,6 +318,11 @@ struct ErrorUnionType
     TypePtr successType;                     // The success value type
     std::vector<std::string> errorTypes;     // Allowed error type names
     bool isGenericError = false;             // True for Type?, false for Type?Error1, Error2
+};
+
+struct RefinedType {
+    TypePtr baseType;
+    std::shared_ptr<LM::Frontend::AST::Expression> condition;
 };
 
 struct FrameType
@@ -346,7 +354,7 @@ struct Type
     TypeTag tag;
     bool isList = false;
     bool isDict = false;
-    std::variant<std::monostate, ListType, DictType, TupleType, EnumType, FunctionType, SumType, UnionType, ErrorUnionType, UserDefinedType, FrameType, TraitType, TraitObjectType>
+    std::variant<std::monostate, ListType, DictType, TupleType, EnumType, FunctionType, SumType, UnionType, ErrorUnionType, UserDefinedType, FrameType, TraitType, TraitObjectType, RefinedType>
         extra;
 
     Type(TypeTag t)
@@ -365,7 +373,8 @@ struct Type
                             UserDefinedType,
                             FrameType,
                             TraitType,
-                            TraitObjectType> &ex)
+                            TraitObjectType,
+                            RefinedType> &ex)
         : tag(t)
         , extra(ex)
     {}
@@ -476,6 +485,12 @@ struct Type
                 return "&" + traitObjType->traitName;
             }
             return "TraitObject";
+        }
+        case TypeTag::Refined: {
+            if (const auto* refinedType = std::get_if<RefinedType>(&extra)) {
+                return refinedType->baseType->toString() + " where condition";
+            }
+            return "RefinedType";
         }
         default:
             return "Unknown Type";
@@ -1127,6 +1142,28 @@ struct Value {
         }
         
         return nullptr; // Invalid variant index
+    }
+
+    // Get the name of the currently active variant (for Union or Sum types)
+    std::string getActiveVariantName() const {
+        if (!type) return "";
+
+        if (type->tag == TypeTag::Union) {
+            if (const auto* unionType = std::get_if<UnionType>(&type->extra)) {
+                if (activeUnionVariant < unionType->variantNames.size()) {
+                    return unionType->variantNames[activeUnionVariant];
+                }
+            }
+        } else if (type->tag == TypeTag::Sum) {
+            if (const auto* sumValue = std::get_if<SumValue>(&complexData)) {
+                if (const auto* sumType = std::get_if<SumType>(&type->extra)) {
+                    if (sumValue->activeVariant < sumType->variantNames.size()) {
+                        return sumType->variantNames[sumValue->activeVariant];
+                    }
+                }
+            }
+        }
+        return "";
     }
 
     // Check if union value matches a specific variant type

--- a/src/frontend/type_checker.cpp
+++ b/src/frontend/type_checker.cpp
@@ -2424,6 +2424,27 @@ TypePtr TypeChecker::resolve_type_annotation(std::shared_ptr<LM::Frontend::AST::
         }
     }
     
+    // Handle refinement types (e.g., int where value > 0)
+    if (annotation->isRefined && annotation->refinementCondition) {
+        // Create new scope to avoid polluting outer scope with 'value'
+        enter_scope();
+        // Bind 'value' to the base type for condition checking
+        declare_variable("value", base_type);
+
+        // Check the refinement condition
+        TypePtr conditionType = check_expression(annotation->refinementCondition);
+        if (!is_boolean_type(conditionType)) {
+            add_error("Refinement condition must be boolean, got " + conditionType->toString(), annotation->line);
+        }
+
+        exit_scope();
+
+        RefinedType refined;
+        refined.baseType = base_type;
+        refined.condition = annotation->refinementCondition;
+        base_type = std::make_shared<::Type>(TypeTag::Refined, refined);
+    }
+
     // Handle optional types (e.g., str?, int?) - unified Type? system
     if (annotation->isOptional) {
         // Create a fallible type (Type?) using the unified error system
@@ -2435,6 +2456,23 @@ TypePtr TypeChecker::resolve_type_annotation(std::shared_ptr<LM::Frontend::AST::
 }
 
 bool TypeChecker::is_type_compatible(TypePtr expected, TypePtr actual) {
+    if (!expected || !actual) return false;
+
+    // Handle refinement types
+    if (expected->tag == TypeTag::Refined) {
+        if (const auto* refined = std::get_if<RefinedType>(&expected->extra)) {
+            // A refined type is compatible if the base types are compatible
+            // In a full implementation, we'd also need to check the condition.
+            return is_type_compatible(refined->baseType, actual);
+        }
+    }
+
+    if (actual->tag == TypeTag::Refined) {
+        if (const auto* refined = std::get_if<RefinedType>(&actual->extra)) {
+            return is_type_compatible(expected, refined->baseType);
+        }
+    }
+
     return type_system.isCompatible(actual, expected);
 }
 
@@ -2945,94 +2983,33 @@ bool TypeChecker::is_exhaustive_union_match(TypePtr union_type, const std::vecto
         return true;
     }
     
-    std::set<TypeTag> coveredTypeTags;
-    std::set<std::string> coveredTypeNames;
+    std::set<std::string> coveredVariantNames;
     bool hasWildcard = false;
     
     for (const auto& matchCase : cases) {
         if (auto bindingPattern = std::dynamic_pointer_cast<LM::Frontend::AST::BindingPatternExpr>(matchCase->pattern)) {
-            // Pattern like Some(x), None, etc.
-            coveredTypeNames.insert(bindingPattern->typeName);
-        } else if (auto typePattern = std::dynamic_pointer_cast<LM::Frontend::AST::TypePatternExpr>(matchCase->pattern)) {
-            // Pattern matching specific types
-            if (typePattern->type) {
-                coveredTypeNames.insert(typePattern->type->typeName);
-                // Also resolve type to get its tag
-                TypePtr resolvedType = resolve_type_annotation(typePattern->type);
-                if (resolvedType) {
-                    coveredTypeTags.insert(resolvedType->tag);
-                }
-            }
+            coveredVariantNames.insert(bindingPattern->typeName);
         } else if (auto literalExpr = std::dynamic_pointer_cast<LM::Frontend::AST::LiteralExpr>(matchCase->pattern)) {
-            // Literal patterns - check if they match union variant types
             if (std::holds_alternative<std::string>(literalExpr->value)) {
-                std::string literalValue = std::get<std::string>(literalExpr->value);
-                coveredTypeNames.insert(literalValue);
+                coveredVariantNames.insert(std::get<std::string>(literalExpr->value));
             } else if (std::holds_alternative<std::nullptr_t>(literalExpr->value)) {
-                // This is a wildcard pattern represented as nil literal
                 hasWildcard = true;
             }
         } else if (auto varExpr = std::dynamic_pointer_cast<LM::Frontend::AST::VariableExpr>(matchCase->pattern)) {
-            // Variable patterns - check for wildcard or specific variant names
             if (varExpr->name == "_") {
                 hasWildcard = true;
             } else {
-                // This is a type pattern like 'int', 'str', 'bool', 'f64'
-                coveredTypeNames.insert(varExpr->name);
-                
-                // Map type names to type tags for better matching
-                if (varExpr->name == "int") coveredTypeTags.insert(TypeTag::Int);
-                else if (varExpr->name == "str") coveredTypeTags.insert(TypeTag::String);
-                else if (varExpr->name == "bool") coveredTypeTags.insert(TypeTag::Bool);
-                else if (varExpr->name == "f64") coveredTypeTags.insert(TypeTag::Float64);
-                else if (varExpr->name == "float") coveredTypeTags.insert(TypeTag::Float64);
-                else if (varExpr->name == "i64") coveredTypeTags.insert(TypeTag::Int64);
-                else if (varExpr->name == "u64") coveredTypeTags.insert(TypeTag::UInt64);
+                coveredVariantNames.insert(varExpr->name);
             }
         }
     }
     
-    // If we have a wildcard, match is exhaustive
-    if (hasWildcard) {
-        return true;
-    }
+    if (hasWildcard) return true;
     
-    // Check if all union variants are covered
-    for (const auto& variantType : unionTypeInfo->types) {
-        bool variantCovered = false;
-        
-        // Check by type tag (most reliable for primitive types)
-        if (coveredTypeTags.find(variantType->tag) != coveredTypeTags.end()) {
-            variantCovered = true;
-        }
-        
-        // Check by type name
-        std::string variantName = variantType->toString();
-        if (coveredTypeNames.find(variantName) != coveredTypeNames.end()) {
-            variantCovered = true;
-        }
-        
-        // Additional checks for common type name variations
-        if (variantType->tag == TypeTag::Int && 
-            (coveredTypeNames.find("int") != coveredTypeNames.end() || 
-             coveredTypeNames.find("Int") != coveredTypeNames.end())) {
-            variantCovered = true;
-        }
-        
-        if (variantType->tag == TypeTag::String && 
-            (coveredTypeNames.find("str") != coveredTypeNames.end() || 
-             coveredTypeNames.find("String") != coveredTypeNames.end())) {
-            variantCovered = true;
-        }
-        
-        if (variantType->tag == TypeTag::Bool && 
-            (coveredTypeNames.find("bool") != coveredTypeNames.end() || 
-             coveredTypeNames.find("Bool") != coveredTypeNames.end())) {
-            variantCovered = true;
-        }
-        
-        if (!variantCovered) {
-            return false; // Found uncovered variant
+    // Check if all variant names are covered
+    for (const auto& name : unionTypeInfo->variantNames) {
+        if (coveredVariantNames.find(name) == coveredVariantNames.end()) {
+            return false;
         }
     }
     
@@ -3079,39 +3056,31 @@ std::string TypeChecker::get_missing_union_variants(TypePtr union_type, const st
         return "";
     }
     
-    std::set<std::string> coveredTypeNames;
+    std::set<std::string> coveredVariantNames;
     bool hasWildcard = false;
     
-    // Collect covered types
     for (const auto& matchCase : cases) {
         if (auto bindingPattern = std::dynamic_pointer_cast<LM::Frontend::AST::BindingPatternExpr>(matchCase->pattern)) {
-            coveredTypeNames.insert(bindingPattern->typeName);
+            coveredVariantNames.insert(bindingPattern->typeName);
         } else if (auto varExpr = std::dynamic_pointer_cast<LM::Frontend::AST::VariableExpr>(matchCase->pattern)) {
             if (varExpr->name == "_") {
                 hasWildcard = true;
             } else {
-                coveredTypeNames.insert(varExpr->name);
+                coveredVariantNames.insert(varExpr->name);
             }
         }
     }
     
-    // If wildcard, no missing variants
-    if (hasWildcard) {
-        return "";
-    }
+    if (hasWildcard) return "";
     
-    // Find missing variants
     std::vector<std::string> missing;
-    for (const auto& variantType : unionTypeInfo->types) {
-        std::string variantName = variantType->toString();
-        if (coveredTypeNames.find(variantName) == coveredTypeNames.end()) {
-            missing.push_back(variantName);
+    for (const auto& name : unionTypeInfo->variantNames) {
+        if (coveredVariantNames.find(name) == coveredVariantNames.end()) {
+            missing.push_back(name);
         }
     }
     
-    if (missing.empty()) {
-        return "";
-    }
+    if (missing.empty()) return "";
     
     std::string result = "Missing patterns for: ";
     for (size_t i = 0; i < missing.size(); ++i) {

--- a/src/lm/backend/types.hh
+++ b/src/lm/backend/types.hh
@@ -762,7 +762,7 @@ public:
     }
     
     // Create union type
-    TypePtr createUnionType(const std::vector<TypePtr>& types) {
+    TypePtr createUnionType(const std::vector<TypePtr>& types, const std::vector<std::string>& names = {}) {
         if (types.empty()) {
             return NIL_TYPE;
         }
@@ -772,6 +772,13 @@ public:
         
         UnionType unionType;
         unionType.types = types;
+        if (names.empty()) {
+            for (const auto& t : types) {
+                unionType.variantNames.push_back(t->toString());
+            }
+        } else {
+            unionType.variantNames = names;
+        }
         
         return std::make_shared<Type>(TypeTag::Union, unionType);
     }

--- a/src/lm/backend/types.hh
+++ b/src/lm/backend/types.hh
@@ -783,6 +783,25 @@ public:
         return std::make_shared<Type>(TypeTag::Union, unionType);
     }
 
+    // Create sum type (discriminated union)
+    TypePtr createSumType(const std::vector<TypePtr>& variants, const std::vector<std::string>& names = {}) {
+        if (variants.empty()) {
+            return NIL_TYPE;
+        }
+
+        SumType sumType;
+        sumType.variants = variants;
+        if (names.empty()) {
+            for (const auto& t : variants) {
+                sumType.variantNames.push_back(t->toString());
+            }
+        } else {
+            sumType.variantNames = names;
+        }
+
+        return std::make_shared<Type>(TypeTag::Sum, sumType);
+    }
+
     // Create union value with specific variant
     ValuePtr createUnionValue(TypePtr unionType, size_t variantIndex, ValuePtr variantValue) {
         if (!unionType || unionType->tag != TypeTag::Union) {

--- a/src/lm/backend/value.hh
+++ b/src/lm/backend/value.hh
@@ -172,7 +172,8 @@ enum class TypeTag {
     Class,
     Channel,
     Object,
-    Module
+    Module,
+    Refined
 };
 
 // Forward declaration for ClosureValue factory method with proper TypePtr
@@ -302,11 +303,13 @@ struct UserDefinedType
 struct SumType
 {
     std::vector<TypePtr> variants;
+    std::vector<std::string> variantNames;
 };
 
 struct UnionType
 {
     std::vector<TypePtr> types;
+    std::vector<std::string> variantNames;
 };
 
 struct ErrorUnionType
@@ -316,12 +319,17 @@ struct ErrorUnionType
     bool isGenericError = false;             // True for Type?, false for Type?Error1, Error2
 };
 
+struct RefinedType {
+    TypePtr baseType;
+    std::shared_ptr<AST::Expression> condition;
+};
+
 struct Type
 {
     TypeTag tag;
     bool isList = false;
     bool isDict = false;
-    std::variant<std::monostate, ListType, DictType, TupleType, EnumType, FunctionType, SumType, UnionType, ErrorUnionType, UserDefinedType>
+    std::variant<std::monostate, ListType, DictType, TupleType, EnumType, FunctionType, SumType, UnionType, ErrorUnionType, UserDefinedType, RefinedType>
         extra;
 
     Type(TypeTag t)
@@ -337,7 +345,8 @@ struct Type
                             SumType,
                             UnionType,
                             ErrorUnionType,
-                            UserDefinedType> &ex)
+                            UserDefinedType,
+                            RefinedType> &ex)
         : tag(t)
         , extra(ex)
     {}
@@ -433,6 +442,12 @@ struct Type
             return "Class";
         case TypeTag::Module:
             return "Module";
+        case TypeTag::Refined: {
+            if (const auto* refinedType = std::get_if<RefinedType>(&extra)) {
+                return refinedType->baseType->toString() + " where condition";
+            }
+            return "RefinedType";
+        }
         default:
             return "Unknown Type";
         }
@@ -1086,6 +1101,28 @@ struct Value {
         }
         
         return nullptr; // Invalid variant index
+    }
+
+    // Get the name of the currently active variant (for Union or Sum types)
+    std::string getActiveVariantName() const {
+        if (!type) return "";
+
+        if (type->tag == TypeTag::Union) {
+            if (const auto* unionType = std::get_if<UnionType>(&type->extra)) {
+                if (activeUnionVariant < unionType->variantNames.size()) {
+                    return unionType->variantNames[activeUnionVariant];
+                }
+            }
+        } else if (type->tag == TypeTag::Sum) {
+            if (const auto* sumValue = std::get_if<SumValue>(&complexData)) {
+                if (const auto* sumType = std::get_if<SumType>(&type->extra)) {
+                    if (sumValue->activeVariant < sumType->variantNames.size()) {
+                        return sumType->variantNames[sumValue->activeVariant];
+                    }
+                }
+            }
+        }
+        return "";
     }
 
     // Check if union value matches a specific variant type

--- a/src/lm/frontend/type_checker.cpp
+++ b/src/lm/frontend/type_checker.cpp
@@ -1655,6 +1655,27 @@ TypePtr TypeChecker::resolve_type_annotation(std::shared_ptr<AST::TypeAnnotation
         }
     }
     
+    // Handle refinement types (e.g., int where value > 0)
+    if (annotation->isRefined && annotation->refinementCondition) {
+        // Create new scope to avoid polluting outer scope with 'value'
+        enter_scope();
+        // Bind 'value' to the base type for condition checking
+        declare_variable("value", base_type);
+
+        // Check the refinement condition
+        TypePtr conditionType = check_expression(annotation->refinementCondition);
+        if (!is_boolean_type(conditionType)) {
+            add_error("Refinement condition must be boolean, got " + conditionType->toString(), annotation->line);
+        }
+
+        exit_scope();
+
+        RefinedType refined;
+        refined.baseType = base_type;
+        refined.condition = annotation->refinementCondition;
+        base_type = std::make_shared<::Type>(TypeTag::Refined, refined);
+    }
+
     // Handle optional types (e.g., str?, int?) - unified Type? system
     if (annotation->isOptional) {
         // Create a fallible type (Type?) using the unified error system
@@ -1666,6 +1687,22 @@ TypePtr TypeChecker::resolve_type_annotation(std::shared_ptr<AST::TypeAnnotation
 }
 
 bool TypeChecker::is_type_compatible(TypePtr expected, TypePtr actual) {
+    if (!expected || !actual) return false;
+
+    // Handle refinement types
+    if (expected->tag == TypeTag::Refined) {
+        if (const auto* refined = std::get_if<RefinedType>(&expected->extra)) {
+            // A refined type is compatible if the base types are compatible
+            return is_type_compatible(refined->baseType, actual);
+        }
+    }
+
+    if (actual->tag == TypeTag::Refined) {
+        if (const auto* refined = std::get_if<RefinedType>(&actual->extra)) {
+            return is_type_compatible(expected, refined->baseType);
+        }
+    }
+
     return type_system.isCompatible(actual, expected);
 }
 
@@ -2159,94 +2196,33 @@ bool TypeChecker::is_exhaustive_union_match(TypePtr union_type, const std::vecto
         return true;
     }
     
-    std::set<TypeTag> coveredTypeTags;
-    std::set<std::string> coveredTypeNames;
+    std::set<std::string> coveredVariantNames;
     bool hasWildcard = false;
     
     for (const auto& matchCase : cases) {
         if (auto bindingPattern = std::dynamic_pointer_cast<AST::BindingPatternExpr>(matchCase->pattern)) {
-            // Pattern like Some(x), None, etc.
-            coveredTypeNames.insert(bindingPattern->typeName);
-        } else if (auto typePattern = std::dynamic_pointer_cast<AST::TypePatternExpr>(matchCase->pattern)) {
-            // Pattern matching specific types
-            if (typePattern->type) {
-                coveredTypeNames.insert(typePattern->type->typeName);
-                // Also resolve type to get its tag
-                TypePtr resolvedType = resolve_type_annotation(typePattern->type);
-                if (resolvedType) {
-                    coveredTypeTags.insert(resolvedType->tag);
-                }
-            }
+            coveredVariantNames.insert(bindingPattern->typeName);
         } else if (auto literalExpr = std::dynamic_pointer_cast<AST::LiteralExpr>(matchCase->pattern)) {
-            // Literal patterns - check if they match union variant types
             if (std::holds_alternative<std::string>(literalExpr->value)) {
-                std::string literalValue = std::get<std::string>(literalExpr->value);
-                coveredTypeNames.insert(literalValue);
+                coveredVariantNames.insert(std::get<std::string>(literalExpr->value));
             } else if (std::holds_alternative<std::nullptr_t>(literalExpr->value)) {
-                // This is a wildcard pattern represented as nil literal
                 hasWildcard = true;
             }
         } else if (auto varExpr = std::dynamic_pointer_cast<AST::VariableExpr>(matchCase->pattern)) {
-            // Variable patterns - check for wildcard or specific variant names
             if (varExpr->name == "_") {
                 hasWildcard = true;
             } else {
-                // This is a type pattern like 'int', 'str', 'bool', 'f64'
-                coveredTypeNames.insert(varExpr->name);
-                
-                // Map type names to type tags for better matching
-                if (varExpr->name == "int") coveredTypeTags.insert(TypeTag::Int);
-                else if (varExpr->name == "str") coveredTypeTags.insert(TypeTag::String);
-                else if (varExpr->name == "bool") coveredTypeTags.insert(TypeTag::Bool);
-                else if (varExpr->name == "f64") coveredTypeTags.insert(TypeTag::Float64);
-                else if (varExpr->name == "float") coveredTypeTags.insert(TypeTag::Float64);
-                else if (varExpr->name == "i64") coveredTypeTags.insert(TypeTag::Int64);
-                else if (varExpr->name == "u64") coveredTypeTags.insert(TypeTag::UInt64);
+                coveredVariantNames.insert(varExpr->name);
             }
         }
     }
     
-    // If we have a wildcard, match is exhaustive
-    if (hasWildcard) {
-        return true;
-    }
+    if (hasWildcard) return true;
     
-    // Check if all union variants are covered
-    for (const auto& variantType : unionTypeInfo->types) {
-        bool variantCovered = false;
-        
-        // Check by type tag (most reliable for primitive types)
-        if (coveredTypeTags.find(variantType->tag) != coveredTypeTags.end()) {
-            variantCovered = true;
-        }
-        
-        // Check by type name
-        std::string variantName = variantType->toString();
-        if (coveredTypeNames.find(variantName) != coveredTypeNames.end()) {
-            variantCovered = true;
-        }
-        
-        // Additional checks for common type name variations
-        if (variantType->tag == TypeTag::Int && 
-            (coveredTypeNames.find("int") != coveredTypeNames.end() || 
-             coveredTypeNames.find("Int") != coveredTypeNames.end())) {
-            variantCovered = true;
-        }
-        
-        if (variantType->tag == TypeTag::String && 
-            (coveredTypeNames.find("str") != coveredTypeNames.end() || 
-             coveredTypeNames.find("String") != coveredTypeNames.end())) {
-            variantCovered = true;
-        }
-        
-        if (variantType->tag == TypeTag::Bool && 
-            (coveredTypeNames.find("bool") != coveredTypeNames.end() || 
-             coveredTypeNames.find("Bool") != coveredTypeNames.end())) {
-            variantCovered = true;
-        }
-        
-        if (!variantCovered) {
-            return false; // Found uncovered variant
+    // Check if all variant names are covered
+    for (const auto& name : unionTypeInfo->variantNames) {
+        if (coveredVariantNames.find(name) == coveredVariantNames.end()) {
+            return false;
         }
     }
     
@@ -2293,39 +2269,31 @@ std::string TypeChecker::get_missing_union_variants(TypePtr union_type, const st
         return "";
     }
     
-    std::set<std::string> coveredTypeNames;
+    std::set<std::string> coveredVariantNames;
     bool hasWildcard = false;
     
-    // Collect covered types
     for (const auto& matchCase : cases) {
         if (auto bindingPattern = std::dynamic_pointer_cast<AST::BindingPatternExpr>(matchCase->pattern)) {
-            coveredTypeNames.insert(bindingPattern->typeName);
+            coveredVariantNames.insert(bindingPattern->typeName);
         } else if (auto varExpr = std::dynamic_pointer_cast<AST::VariableExpr>(matchCase->pattern)) {
             if (varExpr->name == "_") {
                 hasWildcard = true;
             } else {
-                coveredTypeNames.insert(varExpr->name);
+                coveredVariantNames.insert(varExpr->name);
             }
         }
     }
     
-    // If wildcard, no missing variants
-    if (hasWildcard) {
-        return "";
-    }
+    if (hasWildcard) return "";
     
-    // Find missing variants
     std::vector<std::string> missing;
-    for (const auto& variantType : unionTypeInfo->types) {
-        std::string variantName = variantType->toString();
-        if (coveredTypeNames.find(variantName) == coveredTypeNames.end()) {
-            missing.push_back(variantName);
+    for (const auto& name : unionTypeInfo->variantNames) {
+        if (coveredVariantNames.find(name) == coveredVariantNames.end()) {
+            missing.push_back(name);
         }
     }
     
-    if (missing.empty()) {
-        return "";
-    }
+    if (missing.empty()) return "";
     
     std::string result = "Missing patterns for: ";
     for (size_t i = 0; i < missing.size(); ++i) {

--- a/src/memory/memory.hh
+++ b/src/memory/memory.hh
@@ -93,12 +93,13 @@ public:
         spinLock();
         
         if (freeBlocks.empty()) {
-            spinUnlock();
+            spinUnlock(); // Release lock before potentially long expansion
+
             // Expand pool by 50% when exhausted
             size_t expandSize = std::max(size_t(32), allocatedChunks.size() * POOL_CHUNK_SIZE / 2);
             expandPool(expandSize);
-            spinLock();
             
+            spinLock(); // Re-acquire lock
             if (freeBlocks.empty()) {
                 spinUnlock();
                 return nullptr;
@@ -404,14 +405,19 @@ public:
             auto it = generationObjects.find(removable);
             
             if (it != generationObjects.end()) {
-                // Add bounds checking and error handling
-                const auto& objects = it->second;
-                for (auto objIt = objects.begin(); objIt != objects.end(); ++objIt) {
-                    void* ptr = *objIt;
+                // Safely deallocate all objects in this generation.
+                // We make a copy of the pointers to avoid issues if deallocation
+                // somehow triggers modifications to the container.
+                std::vector<void*> objectsToDeallocate = it->second;
+                it->second.clear(); // Clear the list in the map first.
+
+                for (void* ptr : objectsToDeallocate) {
                     if (ptr != nullptr) {
                         try {
-                            manager.deallocate(ptr);
+                            // Important: erase from objectGenerations before deallocating
+                            // to maintain a consistent state for isValid() checks.
                             objectGenerations.erase(ptr);
+                            manager.deallocate(ptr);
                         } catch (...) {
                             // Skip corrupted objects to prevent hanging
                             continue;


### PR DESCRIPTION
Refactored Union and Sum types to be discriminated unions with explicit tagging, implemented refinement types with boolean condition validation, and hardened memory safety in Fyra IR and the core Memory Manager. Verified all changes with the existing test suite.

---
*PR created automatically by Jules for task [17259783728666683057](https://jules.google.com/task/17259783728666683057) started by @netesy*