### PR TITLE
Fix boxing/unboxing, add string concat fallback, and improve pattern binding in LIR/typechecker

### DIFF
--- a/src/backend/vm/register.cpp
+++ b/src/backend/vm/register.cpp
@@ -61,31 +61,38 @@ extern "C" {
 
 RegisterValue unbox_register_value(void* boxed_value) {
     if (!boxed_value) {
-        return nullptr;
-    }
-    
-    // Safety check: if the pointer is very small, it's not a valid object
-    if (reinterpret_cast<uintptr_t>(boxed_value) < 4096) {
-        return nullptr;
+        return (int64_t)VAL_NIL;
     }
 
-    // Use the runtime unboxing functions
-    LmBox* box = static_cast<LmBox*>(boxed_value);
-    
-    switch (box->type) {
-        case LM_BOX_INT:
-            return box->value.as_int;
-        case LM_BOX_FLOAT:
-            return box->value.as_float;
-        case LM_BOX_BOOL:
-            return box->value.as_bool ? true : false;
-        case LM_BOX_STRING:
-            return std::string(lm_unbox_string(box));
-        case LM_BOX_NULLPTR:
-            return nullptr;
-        default:
-            return nullptr;
+    // Treat runtime objects (list/dict/tuple/frame/box) via ObjHeader first.
+    ObjHeader* header = static_cast<ObjHeader*>(boxed_value);
+    if (!header) return (int64_t)VAL_NIL;
+
+    if (header->type_id == TYPE_BOX) {
+        LmBox* box = static_cast<LmBox*>(boxed_value);
+        switch (box->type) {
+            case LM_BOX_INT:
+                return (int64_t)BOX_INT(box->value.as_int);
+            case LM_BOX_FLOAT:
+                return box->value.as_float;
+            case LM_BOX_BOOL:
+                return (int64_t)(box->value.as_bool ? VAL_TRUE : VAL_FALSE);
+            case LM_BOX_STRING:
+                return std::string(lm_unbox_string(box));
+            case LM_BOX_NULLPTR:
+                return (int64_t)VAL_NIL;
+            default:
+                return (int64_t)VAL_NIL;
+        }
     }
+
+    // Non-box runtime objects are returned as tagged pointers.
+    if (header->type_id == TYPE_LIST || header->type_id == TYPE_DICT ||
+        header->type_id == TYPE_TUPLE || header->type_id == TYPE_FRAME) {
+        return (int64_t)BOX_PTR(boxed_value);
+    }
+
+    return (int64_t)VAL_NIL;
 }
 
 // Helper functions
@@ -643,6 +650,9 @@ void RegisterVM::execute_instructions(const LIR::LIR_Function& function, size_t 
                     } else {
                         registers[pc->dst] = (int64_t)BOX_INT(to_int(val_a) + to_int(val_b));
                     }
+                } else if (std::holds_alternative<std::string>(val_a) || std::holds_alternative<std::string>(val_b)) {
+                    // String concatenation fallback for mixed/string operands.
+                    registers[pc->dst] = to_string(val_a) + to_string(val_b);
                 } else {
                     registers[pc->dst] = (int64_t)VAL_NIL;
                 }
@@ -1075,7 +1085,7 @@ void RegisterVM::execute_instructions(const LIR::LIR_Function& function, size_t 
                     if (list) {
                         void* result = lm_list_get(static_cast<LmList*>(list), static_cast<uint64_t>(to_int(index_reg)));
                         if (result) {
-                            registers[pc->dst] = (int64_t)BOX_PTR(result);
+                            registers[pc->dst] = unbox_register_value(result);
                         } else {
                             registers[pc->dst] = (int64_t)VAL_NIL;
                         }
@@ -1213,7 +1223,7 @@ void RegisterVM::execute_instructions(const LIR::LIR_Function& function, size_t 
                 // Get the value from the dict
                 void* result = lm_dict_get(static_cast<LmDict*>(dict_ptr), boxed_key);
                 if (result) {
-                    registers[pc->dst] = (int64_t)BOX_PTR(result);
+                    registers[pc->dst] = unbox_register_value(result);
                 } else {
                     registers[pc->dst] = (int64_t)VAL_NIL;
                 }
@@ -1297,7 +1307,7 @@ void RegisterVM::execute_instructions(const LIR::LIR_Function& function, size_t 
                         uint64_t index = static_cast<uint64_t>(to_int(index_reg));
                         void* result = lm_tuple_get(static_cast<LmTuple*>(tuple), index);
                         if (result) {
-                            registers[pc->dst] = (int64_t)BOX_PTR(result);
+                            registers[pc->dst] = unbox_register_value(result);
                         } else {
                             registers[pc->dst] = (int64_t)VAL_NIL;
                         }

--- a/src/frontend/type_checker/patterns.cpp
+++ b/src/frontend/type_checker/patterns.cpp
@@ -9,6 +9,7 @@ namespace Frontend {
 void TypeChecker::validate_pattern_compatibility(std::shared_ptr<LM::Frontend::AST::Expression> pattern_node, TypePtr match_type, int line) {
     if (!pattern_node) return;
     if (!match_type) match_type = type_system.ANY_TYPE;
+    pattern_node->inferred_type = match_type;
 
     if (auto bindingPattern = std::dynamic_pointer_cast<LM::Frontend::AST::BindingPatternExpr>(pattern_node)) {
         if (bindingPattern->typeName == "val") {
@@ -63,6 +64,17 @@ void TypeChecker::validate_pattern_compatibility(std::shared_ptr<LM::Frontend::A
                                       std::to_string(funcType->paramTypes.size()) + " values, but found " +
                                       std::to_string(bindingPattern->patterns.size()), line);
                         } else {
+                            if (funcType->paramTypes.size() == 1) {
+                                bindingPattern->patterns[0]->inferred_type = funcType->paramTypes[0];
+                            } else if (!funcType->paramTypes.empty()) {
+                                auto payload_tuple = std::make_shared<::Type>(::TypeTag::Tuple);
+                                TupleType tuple_extra;
+                                tuple_extra.elementTypes = funcType->paramTypes;
+                                payload_tuple->extra = tuple_extra;
+                                for (auto& nested : bindingPattern->patterns) {
+                                    nested->inferred_type = payload_tuple;
+                                }
+                            }
                             for (size_t i = 0; i < bindingPattern->patterns.size(); ++i) {
                                 validate_pattern_compatibility(bindingPattern->patterns[i], funcType->paramTypes[i], line);
                             }

--- a/src/lir/generator/statements.cpp
+++ b/src/lir/generator/statements.cpp
@@ -81,19 +81,25 @@ void bind_all_vars(Generator* gen, std::shared_ptr<LM::Frontend::AST::Expression
             gen->bind_variable(dict_p->restBinding.value(), val_reg);
         }
     } else if (auto binding = std::dynamic_pointer_cast<LM::Frontend::AST::BindingPatternExpr>(pattern)) {
-         Reg payload = gen->allocate_register();
-         gen->emit_instruction(LIR_Inst(LIR_Op::GetPayload, Type::Ptr, payload, val_reg));
-         if (binding->patterns.size() == 1) {
-             bind_all_vars(gen, binding->patterns[0], payload);
-         } else {
-             for (size_t i = 0; i < binding->patterns.size(); ++i) {
-                 Reg idx_reg = gen->allocate_register();
-                 gen->emit_instruction(LIR_Inst(LIR_Op::LoadConst, Type::I64, idx_reg, std::make_shared<Value>(std::make_shared<::Type>(::TypeTag::Int64), static_cast<int64_t>(i))));
-                 Reg elem = gen->allocate_register();
-                 gen->emit_instruction(LIR_Inst(LIR_Op::TupleGet, Type::Ptr, elem, payload, idx_reg));
-                 bind_all_vars(gen, binding->patterns[i], elem);
-             }
-         }
+        // Treat unresolved bare binding patterns as variable bindings.
+        if (binding->patterns.empty() && binding->typeName != "_" &&
+            binding->typeName != "val" && binding->typeName != "err") {
+            gen->bind_variable(binding->typeName, val_reg);
+            return;
+        }
+        Reg payload = gen->allocate_register();
+        gen->emit_instruction(LIR_Inst(LIR_Op::GetPayload, Type::Ptr, payload, val_reg));
+        if (binding->patterns.size() == 1) {
+            bind_all_vars(gen, binding->patterns[0], payload);
+        } else {
+            for (size_t i = 0; i < binding->patterns.size(); ++i) {
+                Reg idx_reg = gen->allocate_register();
+                gen->emit_instruction(LIR_Inst(LIR_Op::LoadConst, Type::I64, idx_reg, std::make_shared<Value>(std::make_shared<::Type>(::TypeTag::Int64), static_cast<int64_t>(i))));
+                Reg elem = gen->allocate_register();
+                gen->emit_instruction(LIR_Inst(LIR_Op::TupleGet, Type::Ptr, elem, payload, idx_reg));
+                bind_all_vars(gen, binding->patterns[i], elem);
+            }
+        }
     }
 }
 }
@@ -877,10 +883,12 @@ void Generator::emit_return_stmt(LM::Frontend::AST::ReturnStatement& stmt) {
         if (stmt.value) {
             Reg value = emit_expr(*stmt.value);
             // Move the value to the result register
-            emit_instruction(LIR_Inst(LIR_Op::Mov, Type::I64, else_context_.result_register, value, 0));
+            emit_instruction(LIR_Inst(LIR_Op::Mov, Type::Ptr, else_context_.result_register, value, 0));
         } else {
             // No value - store a default value (0)
-            emit_instruction(LIR_Inst(LIR_Op::LoadConst, Type::I64, else_context_.result_register, 0, 0));
+            auto nil_type = std::make_shared<::Type>(::TypeTag::Nil);
+            emit_instruction(LIR_Inst(LIR_Op::LoadConst, Type::Void, else_context_.result_register,
+                                      std::make_shared<Value>(nil_type, "")));
         }
         // Don't emit a return instruction - let the else block continue
     } else {
@@ -1757,9 +1765,15 @@ void Generator::emit_pattern_match(std::shared_ptr<LM::Frontend::AST::Expression
                 }
             }
         } else {
-            // Unresolved variant - should be caught by type checker, but here we just fail
-            emit_instruction(LIR_Inst(LIR_Op::Jump, 0, 0, 0, failure_target->id));
-            add_block_edge(get_current_block(), failure_target);
+            // Bare binding pattern: treat as variable match (always succeeds).
+            if (binding->patterns.empty() && binding->typeName != "_" &&
+                binding->typeName != "val" && binding->typeName != "err") {
+                bind_variable(binding->typeName, val_reg);
+            } else {
+                // Unresolved constructor pattern should fail this case.
+                emit_instruction(LIR_Inst(LIR_Op::Jump, 0, 0, 0, failure_target->id));
+                add_block_edge(get_current_block(), failure_target);
+            }
         }
     } else if (auto list_p = dynamic_cast<LM::Frontend::AST::ListPatternExpr*>(pattern.get())) {
         // Match list length (at least as many as elements)


### PR DESCRIPTION
### Motivation
- Make runtime boxing/unboxing robust for runtime objects and unify how boxed values are mapped back into VM register values. 
- Ensure pattern type information is propagated and support multi-argument constructors/payloads for correct type checking. 
- Make the LIR generator treat unresolved bare binding patterns as variable bindings and fix some register type/emission inconsistencies for else/return handling.

### Description
- Reworked `unbox_register_value` in `src/backend/vm/register.cpp` to inspect `ObjHeader`, handle boxed ints/floats/bools/strings/null, return tagged pointers for lists/dicts/tuples/frames, and default to `VAL_NIL` for unknowns. 
- Replaced direct `BOX_PTR` usage with `unbox_register_value` for `ListIndex`, `DictGet`, and `TupleGet` results so runtime-returned objects are converted to proper register values; `box_register_value` continues to be used when passing values into the runtime. 
- Added a string-concatenation fallback in the `Add` opcode path so mixed string/numeric operands concatenate via `to_string`. 
- In `src/frontend/type_checker/patterns.cpp` set `pattern_node->inferred_type = match_type` and propagate payload types for constructor patterns, creating a tuple payload type for multi-parameter constructors so nested patterns receive the correct inferred types. 
- In `src/lir/generator/statements.cpp` make bare/unresolved binding patterns bind variables directly to the matched register, change emission for else-block returns to use pointer/nil typed instructions, and treat unresolved constructor patterns in matches as either variable bindings or failing branches as appropriate.

### Testing
- Built the project locally with `make` and ran the CTest suite with `ctest`, and the full test suite completed successfully. 
- Exercised frontend pattern/unit tests and LIR generation tests to verify pattern binding and inferred types, and ran VM/runtime tests covering list/dict/tuple access and boxing behavior, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fe0716fc8326b2dcda7f2c95b8c4)