### PR TITLE
Stabilize bitwise operator parsing, lowering, and hex handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,3 +252,7 @@ Always check existing standard library code for patterns:
 - Test files in `tests/` directory for working examples
 
 When in doubt, write concrete, specific code rather than attempting generic abstractions.
+## 2026-06-19 Parser/operator stabilization note
+
+The scanner and parser now recognize the keyword unary logical operator `not` in addition to legacy `!`. Bitwise operators `&`, `|`, `^`, `<<`, and `>>` parse as expression operators with precedence lower than comparison and higher than equality, so `flags & READ == READ` is parsed as `(flags & READ) == READ`. Compound bitwise assignments `&=`, `|=`, `^=`, `<<=`, and `>>=` are accepted as assignment operators. Exponentiation remains right-associative and binds tighter than unary plus/minus: `-2 ** 2` parses as `-(2 ** 2)`, while `2 ** 3 ** 2` parses as `2 ** (3 ** 2)`.
+

--- a/docs/language.md
+++ b/docs/language.md
@@ -126,3 +126,7 @@ Concurrency is bound to the lifetime of the block.
 ### 6.2 Tasks and Workers
 - `task([name in] iterable) { ... }`: Spawn a unit of work.
 - `worker(param in channel) { ... }`: Process elements from a channel.
+## 2026-06-19 Parser/operator stabilization note
+
+The scanner and parser now recognize the keyword unary logical operator `not` in addition to legacy `!`. Bitwise operators `&`, `|`, `^`, `<<`, and `>>` parse as expression operators with precedence lower than comparison and higher than equality, so `flags & READ == READ` is parsed as `(flags & READ) == READ`. Compound bitwise assignments `&=`, `|=`, `^=`, `<<=`, and `>>=` are accepted as assignment operators. Exponentiation remains right-associative and binds tighter than unary plus/minus: `-2 ** 2` parses as `-(2 ** 2)`, while `2 ** 3 ** 2` parses as `2 ** (3 ** 2)`.
+

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -56,3 +56,7 @@ Creates a new communication channel for structured concurrency.
 - `.receive(): T?`: Blocking receive.
 - `.poll(): T?`: Non-blocking receive.
 - `.offer(value): bool`: Non-blocking send.
+## 2026-06-19 Parser/operator stabilization note
+
+The scanner and parser now recognize the keyword unary logical operator `not` in addition to legacy `!`. Bitwise operators `&`, `|`, `^`, `<<`, and `>>` parse as expression operators with precedence lower than comparison and higher than equality, so `flags & READ == READ` is parsed as `(flags & READ) == READ`. Compound bitwise assignments `&=`, `|=`, `^=`, `<<=`, and `>>=` are accepted as assignment operators. Exponentiation remains right-associative and binds tighter than unary plus/minus: `-2 ** 2` parses as `-(2 ** 2)`, while `2 ** 3 ** 2` parses as `2 ** (3 ** 2)`.
+

--- a/src/backend/vm/ops/bitwise.cpp
+++ b/src/backend/vm/ops/bitwise.cpp
@@ -17,6 +17,12 @@ void RegisterVM::execute_bitwise(const LIR::LIR_Inst* pc) {
         case LIR::LIR_Op::Xor:
             registers[pc->dst] = make_i64(to_int(registers[pc->a]) ^ to_int(registers[pc->b]));
             break;
+        case LIR::LIR_Op::Shl:
+            registers[pc->dst] = make_i64(to_int(registers[pc->a]) << to_int(registers[pc->b]));
+            break;
+        case LIR::LIR_Op::Shr:
+            registers[pc->dst] = make_i64(to_int(registers[pc->a]) >> to_int(registers[pc->b]));
+            break;
         default:
             break;
     }

--- a/src/backend/vm/register.cpp
+++ b/src/backend/vm/register.cpp
@@ -163,7 +163,7 @@ void RegisterVM::execute_instructions(const LIR::LIR_Function& function, uint64_
                 execute_control_flow(pc, function); break;
             case LIR::LIR_Op::PrintInt: case LIR::LIR_Op::PrintUint: case LIR::LIR_Op::PrintFloat:
             case LIR::LIR_Op::PrintBool: case LIR::LIR_Op::PrintString: execute_io(pc); break;
-            case LIR::LIR_Op::And: case LIR::LIR_Op::Or: case LIR::LIR_Op::Xor: execute_bitwise(pc); break;
+            case LIR::LIR_Op::And: case LIR::LIR_Op::Or: case LIR::LIR_Op::Xor: case LIR::LIR_Op::Shl: case LIR::LIR_Op::Shr: execute_bitwise(pc); break;
             case LIR::LIR_Op::ChannelAlloc: case LIR::LIR_Op::ChannelSend: case LIR::LIR_Op::ChannelOffer:
             case LIR::LIR_Op::ChannelRecv: case LIR::LIR_Op::ChannelPoll: case LIR::LIR_Op::ChannelClose:
             case LIR::LIR_Op::ChannelHasData: case LIR::LIR_Op::SchedulerInit: case LIR::LIR_Op::SchedulerRun:

--- a/src/frontend/parser.hh
+++ b/src/frontend/parser.hh
@@ -195,6 +195,10 @@ public:
     std::shared_ptr<LM::Frontend::AST::Expression> logicalOr();
     std::shared_ptr<LM::Frontend::AST::Expression> logicalAnd();
     std::shared_ptr<LM::Frontend::AST::Expression> equality();
+    std::shared_ptr<LM::Frontend::AST::Expression> bitwiseOr();
+    std::shared_ptr<LM::Frontend::AST::Expression> bitwiseXor();
+    std::shared_ptr<LM::Frontend::AST::Expression> bitwiseAnd();
+    std::shared_ptr<LM::Frontend::AST::Expression> bitwiseShift();
     std::shared_ptr<LM::Frontend::AST::Expression> comparison();
     std::shared_ptr<LM::Frontend::AST::Expression> term();
     std::shared_ptr<LM::Frontend::AST::Expression> factor();

--- a/src/frontend/parser/expressions.cpp
+++ b/src/frontend/parser/expressions.cpp
@@ -16,7 +16,9 @@ std::shared_ptr<LM::Frontend::AST::Expression> Parser::assignment() {
     auto expr = logicalOr();
 
     if (match({TokenType::EQUAL, TokenType::PLUS_EQUAL, TokenType::MINUS_EQUAL, 
-               TokenType::STAR_EQUAL, TokenType::SLASH_EQUAL, TokenType::MODULUS_EQUAL})) {
+               TokenType::STAR_EQUAL, TokenType::SLASH_EQUAL, TokenType::MODULUS_EQUAL,
+               TokenType::AMPERSAND_EQUAL, TokenType::PIPE_EQUAL, TokenType::CARET_EQUAL,
+               TokenType::LESS_LESS_EQUAL, TokenType::GREATER_GREATER_EQUAL})) {
         Token op = previous();
         auto value = assignment();
 
@@ -88,11 +90,11 @@ std::shared_ptr<LM::Frontend::AST::Expression> Parser::logicalAnd() {
 }
 
 std::shared_ptr<LM::Frontend::AST::Expression> Parser::equality() {
-    auto expr = comparison();
+    auto expr = bitwiseOr();
 
     while (match({TokenType::BANG_EQUAL, TokenType::EQUAL_EQUAL})) {
         auto op = previous();
-        auto right = comparison();
+        auto right = bitwiseOr();
 
         auto binaryExpr = std::make_shared<LM::Frontend::AST::BinaryExpr>();
         binaryExpr->line = op.line;
@@ -117,14 +119,82 @@ std::shared_ptr<LM::Frontend::AST::Expression> Parser::equality() {
     return expr;
 }
 
-std::shared_ptr<LM::Frontend::AST::Expression> Parser::comparison() {
+std::shared_ptr<LM::Frontend::AST::Expression> Parser::bitwiseOr() {
+    auto expr = bitwiseXor();
+
+    while (match({TokenType::PIPE})) {
+        auto op = previous();
+        auto right = bitwiseXor();
+        auto binaryExpr = std::make_shared<LM::Frontend::AST::BinaryExpr>();
+        binaryExpr->line = op.line;
+        binaryExpr->left = expr;
+        binaryExpr->op = op.type;
+        binaryExpr->right = right;
+        expr = binaryExpr;
+    }
+
+    return expr;
+}
+
+std::shared_ptr<LM::Frontend::AST::Expression> Parser::bitwiseXor() {
+    auto expr = bitwiseAnd();
+
+    while (match({TokenType::CARET})) {
+        auto op = previous();
+        auto right = bitwiseAnd();
+        auto binaryExpr = std::make_shared<LM::Frontend::AST::BinaryExpr>();
+        binaryExpr->line = op.line;
+        binaryExpr->left = expr;
+        binaryExpr->op = op.type;
+        binaryExpr->right = right;
+        expr = binaryExpr;
+    }
+
+    return expr;
+}
+
+std::shared_ptr<LM::Frontend::AST::Expression> Parser::bitwiseAnd() {
+    auto expr = comparison();
+
+    while (match({TokenType::AMPERSAND})) {
+        auto op = previous();
+        auto right = comparison();
+        auto binaryExpr = std::make_shared<LM::Frontend::AST::BinaryExpr>();
+        binaryExpr->line = op.line;
+        binaryExpr->left = expr;
+        binaryExpr->op = op.type;
+        binaryExpr->right = right;
+        expr = binaryExpr;
+    }
+
+    return expr;
+}
+
+std::shared_ptr<LM::Frontend::AST::Expression> Parser::bitwiseShift() {
     auto expr = term();
+
+    while (match({TokenType::LESS_LESS, TokenType::GREATER_GREATER})) {
+        auto op = previous();
+        auto right = term();
+        auto binaryExpr = std::make_shared<LM::Frontend::AST::BinaryExpr>();
+        binaryExpr->line = op.line;
+        binaryExpr->left = expr;
+        binaryExpr->op = op.type;
+        binaryExpr->right = right;
+        expr = binaryExpr;
+    }
+
+    return expr;
+}
+
+std::shared_ptr<LM::Frontend::AST::Expression> Parser::comparison() {
+    auto expr = bitwiseShift();
 
     if (match({TokenType::RANGE})) {
         auto rangeExpr = std::make_shared<LM::Frontend::AST::RangeExpr>();
         rangeExpr->line = previous().line;
         rangeExpr->start = expr;
-        rangeExpr->end = term();
+        rangeExpr->end = bitwiseShift();
         rangeExpr->step = nullptr;
         rangeExpr->inclusive = true;
         
@@ -156,7 +226,7 @@ std::shared_ptr<LM::Frontend::AST::Expression> Parser::comparison() {
             continue;
         }
 
-        auto right = term();
+        auto right = bitwiseShift();
 
         auto binaryExpr = std::make_shared<LM::Frontend::AST::BinaryExpr>();
         binaryExpr->line = op.line;
@@ -212,7 +282,7 @@ std::shared_ptr<LM::Frontend::AST::Expression> Parser::term() {
 }
 
 std::shared_ptr<LM::Frontend::AST::Expression> Parser::factor() {
-    auto expr = power();
+    auto expr = unary();
 
     while (match({TokenType::SLASH, TokenType::STAR, TokenType::MODULUS})) {
         auto op = previous();
@@ -242,10 +312,10 @@ std::shared_ptr<LM::Frontend::AST::Expression> Parser::factor() {
 }
 
 std::shared_ptr<LM::Frontend::AST::Expression> Parser::power() {
-    auto expr = unary();
-    while (match({TokenType::POWER})) {
+    auto expr = call();
+    if (match({TokenType::POWER})) {
         auto op = previous();
-        auto right = power();
+        auto right = unary();
         auto binaryExpr = createNodeWithContext<LM::Frontend::AST::BinaryExpr>();
         binaryExpr->line = op.line;
         binaryExpr->left = expr;
@@ -271,9 +341,9 @@ std::shared_ptr<LM::Frontend::AST::Expression> Parser::power() {
 }
 
 std::shared_ptr<LM::Frontend::AST::Expression> Parser::unary() {
-    if (match({TokenType::BANG, TokenType::MINUS, TokenType::PLUS})) {
+    if (match({TokenType::BANG, TokenType::TILDE, TokenType::MINUS, TokenType::PLUS, TokenType::NOT})) {
         auto op = previous();
-        auto right = unary();
+        auto right = (op.type == TokenType::MINUS || op.type == TokenType::PLUS) ? power() : unary();
 
         auto unaryExpr = std::make_shared<LM::Frontend::AST::UnaryExpr>();
         unaryExpr->line = op.line;
@@ -294,7 +364,7 @@ std::shared_ptr<LM::Frontend::AST::Expression> Parser::unary() {
         return unaryExpr;
     }
 
-    return call();
+    return power();
 }
 
 std::shared_ptr<LM::Frontend::AST::Expression> Parser::call() {
@@ -444,7 +514,7 @@ std::shared_ptr<LM::Frontend::AST::Expression> Parser::primary() {
         literalExpr->line = previous().line; literalExpr->value = nullptr;
         attachTriviaFromToken(previous()); return literalExpr;
     }
-    if (match({TokenType::INT_LITERAL, TokenType::FLOAT_LITERAL, TokenType::SCIENTIFIC_LITERAL})) {
+    if (match({TokenType::INT_LITERAL, TokenType::HEX_LITERAL, TokenType::FLOAT_LITERAL, TokenType::SCIENTIFIC_LITERAL})) {
         auto token = previous(); auto literalExpr = createNodeWithContext<LM::Frontend::AST::LiteralExpr>();
         literalExpr->line = token.line; literalExpr->value = token.lexeme; literalExpr->literalType = token.type;
         if (cstMode && config.detailedExpressionNodes) {

--- a/src/frontend/scanner.cpp
+++ b/src/frontend/scanner.cpp
@@ -628,7 +628,13 @@ void Scanner::number() {
         while (isDigit(peek()) || (peek() >= 'a' && peek() <= 'f') || (peek() >= 'A' && peek() <= 'F')) {
             advance();
         }
-        addToken(TokenType::HEX_LITERAL);
+        std::string hexText = source.substr(start, current - start);
+        try {
+            unsigned long long value = std::stoull(hexText, nullptr, 16);
+            addToken(TokenType::INT_LITERAL, std::to_string(value));
+        } catch (const std::exception&) {
+            addToken(TokenType::HEX_LITERAL);
+        }
         return;
     }
     
@@ -717,6 +723,7 @@ TokenType Scanner::checkKeyword(size_t /*start*/, size_t /*length*/, const std::
     if (rest == "for") return TokenType::FOR;
     if (rest == "fn") return TokenType::FN;
     if (rest == "if") return TokenType::IF;
+    if (rest == "not") return TokenType::NOT;
     if (rest == "or") return TokenType::OR;
     if (rest == "print") return TokenType::PRINT;
     if (rest == "return") return TokenType::RETURN;

--- a/src/frontend/scanner.hh
+++ b/src/frontend/scanner.hh
@@ -128,6 +128,7 @@ enum class TokenType {
     IN,         // in
     NIL,        // nil
     ENUM,       // enum
+    NOT,        // not
     OR,         // or
     DEFAULT,    // default
     PRINT,      // print

--- a/src/frontend/type_checker/expressions.cpp
+++ b/src/frontend/type_checker/expressions.cpp
@@ -135,6 +135,7 @@ TypePtr TypeChecker::check_literal_expr(std::shared_ptr<LM::Frontend::AST::Liter
         // Use the token type to determine the correct type
         switch (expr->literalType) {
             case TokenType::INT_LITERAL:
+            case TokenType::HEX_LITERAL:
                 if (expected_type && is_decimal_type(expected_type)) {
                     expr->inferred_type = expected_type;
                     return expected_type;
@@ -177,7 +178,8 @@ TypePtr TypeChecker::check_literal_expr_with_expected_type(std::shared_ptr<LM::F
         
         // Use the token type to determine the correct type
         switch (expr->literalType) {
-            case TokenType::INT_LITERAL: {
+            case TokenType::INT_LITERAL:
+            case TokenType::HEX_LITERAL: {
                 // If we have an expected type and it's an integer type or decimal type, use it
                 if (expected_type && (is_integer_type(expected_type) || is_decimal_type(expected_type))) {
                     expr->inferred_type = expected_type;
@@ -431,6 +433,20 @@ TypePtr TypeChecker::check_binary_expr(std::shared_ptr<LM::Frontend::AST::Binary
             add_error("Logical operations require boolean operands", expr->line);
             return type_system.BOOL_TYPE;
             
+        case TokenType::AMPERSAND:
+        case TokenType::PIPE:
+        case TokenType::CARET:
+        case TokenType::LESS_LESS:
+        case TokenType::GREATER_GREATER:
+            if (left_base->tag == TypeTag::Any || right_base->tag == TypeTag::Any) {
+                return type_system.ANY_TYPE;
+            }
+            if (is_integer_type(left_base) && is_integer_type(right_base)) {
+                return promote_numeric_types(left_base, right_base);
+            }
+            add_error("Bitwise operations require integer operands", expr->line);
+            return type_system.INT_TYPE;
+
         case TokenType::MODULUS:
         case TokenType::POWER:
             if (left_base->tag == TypeTag::Any || right_base->tag == TypeTag::Any) {
@@ -469,12 +485,20 @@ TypePtr TypeChecker::check_unary_expr(std::shared_ptr<LM::Frontend::AST::UnaryEx
 
     switch (expr->op) {
         case TokenType::BANG:
+        case TokenType::NOT:
             // Logical NOT
             if (right_type->tag != TypeTag::Any && !is_boolean_type(right_type)) {
                 add_type_error("bool", right_type->toString(), expr->line);
             }
             return type_system.BOOL_TYPE;
             
+        case TokenType::TILDE:
+            if (right_base->tag != TypeTag::Any && !is_integer_type(right_base)) {
+                add_type_error("integer", right_base->toString(), expr->line);
+            }
+            expr->inferred_type = right_base;
+            return right_base;
+
         case TokenType::MINUS:
         case TokenType::PLUS:
             // Numeric negation/affirmation

--- a/src/lir/generator/expressions.cpp
+++ b/src/lir/generator/expressions.cpp
@@ -917,9 +917,11 @@ Reg Generator::emit_binary_expr(LM::Frontend::AST::BinaryExpr& expr) {
     else if (expr.op == LM::Frontend::TokenType::LESS_EQUAL) op = LIR_Op::CmpLE;
     else if (expr.op == LM::Frontend::TokenType::GREATER) op = LIR_Op::CmpGT;
     else if (expr.op == LM::Frontend::TokenType::GREATER_EQUAL) op = LIR_Op::CmpGE;
-
-
+    else if (expr.op == LM::Frontend::TokenType::AMPERSAND) op = LIR_Op::And;
+    else if (expr.op == LM::Frontend::TokenType::PIPE) op = LIR_Op::Or;
     else if (expr.op == LM::Frontend::TokenType::CARET) op = LIR_Op::Xor;
+    else if (expr.op == LM::Frontend::TokenType::LESS_LESS) op = LIR_Op::Shl;
+    else if (expr.op == LM::Frontend::TokenType::GREATER_GREATER) op = LIR_Op::Shr;
     else {
         report_error("Unknown binary operator");
         return 0;
@@ -1067,10 +1069,12 @@ Reg Generator::emit_binary_expr(LM::Frontend::AST::BinaryExpr& expr) {
             }
         }
     } else if (op == LIR_Op::And || op == LIR_Op::Or) {
-        // Logical operations return bool
-        result_type = std::make_shared<::Type>(::TypeTag::Bool);
-    } else if (op == LIR_Op::Xor) {
-        // Bitwise XOR should preserve integer types like arithmetic operations
+        if (expr.op == LM::Frontend::TokenType::AND || expr.op == LM::Frontend::TokenType::OR) {
+            result_type = std::make_shared<::Type>(::TypeTag::Bool);
+        } else {
+            result_type = get_promoted_numeric_type(left_type, right_type);
+        }
+    } else if (op == LIR_Op::Xor || op == LIR_Op::Shl || op == LIR_Op::Shr) {
         result_type = get_promoted_numeric_type(left_type, right_type);
     }
     
@@ -1107,7 +1111,7 @@ Reg Generator::emit_unary_expr(LM::Frontend::AST::UnaryExpr& expr) {
         set_register_type(dst, result_type);
         // Unary plus - just copy the value (no operation needed)
         emit_instruction(LIR_Inst(LIR_Op::Mov, dst, operand, 0));
-    } else if (expr.op == LM::Frontend::TokenType::BANG) {
+    } else if (expr.op == LM::Frontend::TokenType::BANG || expr.op == LM::Frontend::TokenType::NOT) {
         // Result type is bool
         result_type = std::make_shared<::Type>(::TypeTag::Bool);
         set_register_type(dst, result_type);

--- a/src/lir/lir.cpp
+++ b/src/lir/lir.cpp
@@ -37,6 +37,8 @@ std::string LIR_Inst::to_string() const {
         case LIR_Op::And:
         case LIR_Op::Or:
         case LIR_Op::Xor:
+        case LIR_Op::Shl:
+        case LIR_Op::Shr:
         case LIR_Op::CmpEQ:
         case LIR_Op::CmpNEQ:
         case LIR_Op::CmpLT:
@@ -243,6 +245,8 @@ std::string lir_op_to_string(LIR_Op op) {
         case LIR_Op::And: return "and";
         case LIR_Op::Or: return "or";
         case LIR_Op::Xor: return "xor";
+        case LIR_Op::Shl: return "shl";
+        case LIR_Op::Shr: return "shr";
         case LIR_Op::CmpEQ: return "cmpeq";
         case LIR_Op::CmpNEQ: return "cmpneq";
         case LIR_Op::CmpLT: return "cmplt";

--- a/src/lir/lir.hh
+++ b/src/lir/lir.hh
@@ -79,7 +79,7 @@ enum class ResourceOperation : uint32_t {
 
 enum class LIR_Op : uint8_t {
     // === Core Operations ===
-    Mov, LoadConst, Add, Sub, Mul, Div, Mod, Neg, And, Or, Xor,
+    Mov, LoadConst, Add, Sub, Mul, Div, Mod, Neg, And, Or, Xor, Shl, Shr,
     CmpEQ, CmpNEQ, CmpLT, CmpLE, CmpGT, CmpGE, StringIndex,
     Jump, JumpIfFalse, JumpIf, Label,
     Call, CallVoid, CallIndirect, CallBuiltin, CallVariadic,


### PR DESCRIPTION
### Motivation
- Make bitwise operators, shifts, and related compound assignments parse with correct precedence and be supported end-to-end by the compiler pipeline. 
- Ensure exponentiation/unary precedence behaves according to the language rules (right-associative power, unary binds outside power). 
- Normalize hex literals early and add a keyword `not` for unary logical negation to match language docs. 

### Description
- Parser: introduced explicit precedence tiers for bitwise OR/XOR/AND and shifts, wired them into the expression grammar, and accepted compound bitwise assignment operators (`&=`, `|=`, `^=`, `<<=`, `>>=`). 
- Scanner: added `not` keyword recognition and normalized `0x...` hex tokens into integer literals when possible so downstream phases get numeric `INT_LITERAL` values. 
- Type checker: added handling and checking for bitwise binary operators and unary `~` (tilde) as integer operations and accepted `not` as logical negation. 
- LIR/Generator: added `Shl`/`Shr` ops and lowered the parser token kinds to LIR ops for `<<`/`>>` and other bitwise operators; adjusted result-type inference to preserve integer promotion for bitwise and shift ops. 
- VM: extended the register VM bitwise dispatcher to execute `Shl`/`Shr` alongside `And`/`Or`/`Xor`. 
- Documentation: updated `docs/language.md`, `docs/stdlib.md`, and `AGENTS.md` with a parser/operator stabilization note describing the semantics and precedence. 

### Testing
- Built the project with `make clean && make -j2` which completed successfully. 
- Ran AST inspection with `./bin/limitly -ast <source>` to validate parsing of precedence cases (e.g., `flags & READ == READ`, `-2 ** 2`, `2 ** 3 ** 2`) and observed expected AST shapes. 
- Executed the bitwise smoke test `./bin/limitly run tests/bitwise_test_simple.lm` and obtained the expected runtime outputs for bitwise ops, shifts, negation, and hex literal values. 
- Attempted `make tests -j2`; this target failed in this environment because the `./bin/lyra` tool required by the test harness is not present, so the full project test-suite could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3543177da8832aab063f00bd3ed30d)