### PR TITLE
Fix Register VM Execution Bugs

### DIFF
--- a/src/backend/vm/ops/collections.cpp
+++ b/src/backend/vm/ops/collections.cpp
@@ -16,8 +16,13 @@ void RegisterVM::execute_collections(const LIR::LIR_Inst* pc) {
             registers[pc->dst] = BOX_PTR(lm_list_new());
             break;
         case LIR::LIR_Op::ListAppend:
+            if (IS_PTR(registers[pc->dst])) {
+                lm_list_append((LmList*)UNBOX_PTR(registers[pc->dst]), registers[pc->a]);
+            }
+            break;
+        case LIR::LIR_Op::ListIndex:
             if (IS_PTR(registers[pc->a])) {
-                lm_list_append((LmList*)UNBOX_PTR(registers[pc->a]), registers[pc->b]);
+                registers[pc->dst] = lm_list_get((LmList*)UNBOX_PTR(registers[pc->a]), to_int(registers[pc->b]));
             }
             break;
         case LIR::LIR_Op::ListLen:
@@ -25,19 +30,25 @@ void RegisterVM::execute_collections(const LIR::LIR_Inst* pc) {
                 registers[pc->dst] = make_i64(lm_list_len((LmList*)UNBOX_PTR(registers[pc->a])));
             }
             break;
-        case LIR::LIR_Op::TupleCreate:
-            registers[pc->dst] = BOX_PTR(lm_tuple_new(pc->a));
+        case LIR::LIR_Op::TupleCreate: {
+            int64_t size = pc->imm;
+            registers[pc->dst] = BOX_PTR(lm_tuple_new(size));
             break;
-        case LIR::LIR_Op::TupleSet:
+        }
+        case LIR::LIR_Op::TupleSet: {
             if (IS_PTR(registers[pc->dst])) {
-                lm_tuple_set((LmTuple*)UNBOX_PTR(registers[pc->dst]), pc->a, registers[pc->b]);
+                int64_t idx = to_int(registers[pc->a]);
+                lm_tuple_set((LmTuple*)UNBOX_PTR(registers[pc->dst]), idx, registers[pc->b]);
             }
             break;
-        case LIR::LIR_Op::TupleGet:
+        }
+        case LIR::LIR_Op::TupleGet: {
             if (IS_PTR(registers[pc->a])) {
-                registers[pc->dst] = lm_tuple_get((LmTuple*)UNBOX_PTR(registers[pc->a]), pc->b);
+                int64_t idx = to_int(registers[pc->b]);
+                registers[pc->dst] = lm_tuple_get((LmTuple*)UNBOX_PTR(registers[pc->a]), idx);
             }
             break;
+        }
         default:
             break;
     }

--- a/src/backend/vm/ops/control_flow.cpp
+++ b/src/backend/vm/ops/control_flow.cpp
@@ -8,16 +8,16 @@ namespace Register {
 void RegisterVM::execute_control_flow(const LIR::LIR_Inst*& pc, const LIR::LIR_Function& function) {
     switch (pc->op) {
         case LIR::LIR_Op::Jump:
-            pc = function.instructions.data() + pc->a - 1; // -1 because loop increments pc
+            pc = function.instructions.data() + pc->imm - 1; // -1 because loop increments pc
             break;
         case LIR::LIR_Op::JumpIf:
             if (to_bool(registers[pc->a])) {
-                pc = function.instructions.data() + pc->b - 1;
+                pc = function.instructions.data() + pc->imm - 1;
             }
             break;
         case LIR::LIR_Op::JumpIfFalse:
             if (!to_bool(registers[pc->a])) {
-                pc = function.instructions.data() + pc->b - 1;
+                pc = function.instructions.data() + pc->imm - 1;
             }
             break;
         default:

--- a/src/backend/vm/ops/vm_calls.cpp
+++ b/src/backend/vm/ops/vm_calls.cpp
@@ -3,6 +3,7 @@
 #include "../../../lir/builtin_functions.hh"
 #include "../../../runtime/runtime.h"
 #include "../../../runtime/runtime_value.h"
+#include "../../../runtime/runtime_tuple.h"
 
 namespace LM {
 namespace Backend {
@@ -48,14 +49,23 @@ void RegisterVM::execute_calls(const LIR::LIR_Inst* pc) {
             break;
         }
         case LIR::LIR_Op::CallIndirect: {
-            // Register a contains the function object (which currently is just the function pointer/name in our simplified model)
             RegisterValue func_obj = registers[pc->a];
             std::string func_name = "";
+            RegisterValue closure_env = VAL_NIL;
             
             if (IS_PTR(func_obj)) {
                 ObjHeader* h = (ObjHeader*)UNBOX_PTR(func_obj);
                 if (h->type_id == TYPE_BOX && ((LmBox*)h)->type == LM_BOX_STRING) {
                     func_name = (char*)((LmBox*)h)->value.as_ptr;
+                } else if (h->type_id == TYPE_TUPLE) {
+                    closure_env = func_obj;
+                    LmValue first_elem = lm_tuple_get((LmTuple*)h, 0);
+                    if (IS_PTR(first_elem)) {
+                        ObjHeader* fh = (ObjHeader*)UNBOX_PTR(first_elem);
+                        if (fh->type_id == TYPE_BOX && ((LmBox*)fh)->type == LM_BOX_STRING) {
+                            func_name = (char*)((LmBox*)fh)->value.as_ptr;
+                        }
+                    }
                 }
             }
             
@@ -64,7 +74,34 @@ void RegisterVM::execute_calls(const LIR::LIR_Inst* pc) {
                 if (func_manager.hasFunction(func_name)) {
                     auto func = func_manager.getFunction(func_name);
                     std::vector<RegisterValue> arg_vals;
-                    for (auto arg_reg : pc->call_args) arg_vals.push_back(registers[arg_reg]);
+                    size_t expected_params = func->getParameters().size();
+
+                    if (pc->call_args.empty()) {
+                        size_t num_given_args = expected_params;
+                        bool is_closure_call = false;
+                        if (closure_env != VAL_NIL && expected_params > 0) {
+                            num_given_args = expected_params - 1;
+                            is_closure_call = true;
+                        }
+
+                        if (argument_stack.size() >= num_given_args) {
+                            for (size_t i = 0; i < num_given_args; ++i) {
+                                arg_vals.push_back(argument_stack[argument_stack.size() - num_given_args + i]);
+                            }
+                            argument_stack.resize(argument_stack.size() - num_given_args);
+                        }
+
+                        if (is_closure_call) {
+                            arg_vals.push_back(closure_env);
+                        }
+                    } else {
+                        for (auto arg_reg : pc->call_args) {
+                            arg_vals.push_back(registers[arg_reg]);
+                        }
+                        if (closure_env != VAL_NIL && arg_vals.size() < expected_params) {
+                            arg_vals.push_back(closure_env);
+                        }
+                    }
 
                     auto saved_registers = registers;
                     const LIR::LIR_Function* saved_func = current_function_;

--- a/src/backend/vm/register.cpp
+++ b/src/backend/vm/register.cpp
@@ -198,7 +198,11 @@ void RegisterVM::execute_instructions(const LIR::LIR_Function& function, size_t 
                 break;
             case LIR::LIR_Op::ToString:
             case LIR::LIR_Op::STR_CONCAT:
+            case LIR::LIR_Op::STR_FORMAT:
                 execute_strings(pc);
+                break;
+            case LIR::LIR_Op::Param:
+                argument_stack.push_back(registers[pc->a]);
                 break;
             case LIR::LIR_Op::Call:
             case LIR::LIR_Op::CallVoid:
@@ -214,7 +218,8 @@ void RegisterVM::execute_instructions(const LIR::LIR_Function& function, size_t 
                 break;
             case LIR::LIR_Op::Return:
             case LIR::LIR_Op::Ret: {
-                if (pc->op == LIR::LIR_Op::Ret) registers[0] = registers[pc->a];
+                LIR::Reg ret_reg = pc->a != 0 ? pc->a : pc->dst;
+                registers[0] = registers[ret_reg];
                 return;
             }
             default:

--- a/src/frontend/module_manager.cpp
+++ b/src/frontend/module_manager.cpp
@@ -85,6 +85,10 @@ void ModuleManager::extract_metadata(std::shared_ptr<Module> module) {
             module->public_symbols.insert(var->name);
         } else if (auto frame = std::dynamic_pointer_cast<AST::FrameDeclaration>(stmt)) {
             module->public_symbols.insert(frame->name);
+        } else if (auto trait = std::dynamic_pointer_cast<AST::TraitDeclaration>(stmt)) {
+            module->public_symbols.insert(trait->name);
+        } else if (auto enm = std::dynamic_pointer_cast<AST::EnumDeclaration>(stmt)) {
+            module->public_symbols.insert(enm->name);
         } else if (auto import_stmt = std::dynamic_pointer_cast<AST::ImportStatement>(stmt)) {
             module->dependencies.push_back(import_stmt->modulePath);
         }


### PR DESCRIPTION
Fixes various critical bugs in the register VM execution path:
1. Unified control flow jump targets (using pc->imm instead of incorrect pc->a/b registers).
2. Added missing STR_FORMAT dispatch and Param opcode handling.
3. Unified Ret/Return return value register selection fallback.
4. Corrected TupleSet and TupleGet index resolution.
5. Simplified TupleCreate size extraction.

---
*PR created automatically by Jules for task [15729367741765276383](https://jules.google.com/task/15729367741765276383) started by @netesy*