### PR TITLE
Fix and Stabilize LIR Generator, VM Control Flow, and Type Assertions

### DIFF
--- a/src/backend/vm/ops/control_flow.cpp
+++ b/src/backend/vm/ops/control_flow.cpp
@@ -7,19 +7,37 @@ namespace Register {
 
 void RegisterVM::execute_control_flow(const LIR::LIR_Inst*& pc, const LIR::LIR_Function& function) {
     switch (pc->op) {
-        case LIR::LIR_Op::Jump:
-            pc = function.instructions.data() + pc->imm - 1; // -1 because loop increments pc
+        case LIR::LIR_Op::Jump: {
+            uint64_t target = pc->imm;
+            auto it = current_label_map_.find(static_cast<uint32_t>(pc->imm));
+            if (it != current_label_map_.end()) {
+                target = it->second;
+            }
+            pc = function.instructions.data() + target - 1; // -1 because loop increments pc
             break;
-        case LIR::LIR_Op::JumpIf:
+        }
+        case LIR::LIR_Op::JumpIf: {
             if (to_bool(registers[pc->a])) {
-                pc = function.instructions.data() + pc->imm - 1;
+                uint64_t target = pc->imm;
+                auto it = current_label_map_.find(static_cast<uint32_t>(pc->imm));
+                if (it != current_label_map_.end()) {
+                    target = it->second;
+                }
+                pc = function.instructions.data() + target - 1;
             }
             break;
-        case LIR::LIR_Op::JumpIfFalse:
+        }
+        case LIR::LIR_Op::JumpIfFalse: {
             if (!to_bool(registers[pc->a])) {
-                pc = function.instructions.data() + pc->imm - 1;
+                uint64_t target = pc->imm;
+                auto it = current_label_map_.find(static_cast<uint32_t>(pc->imm));
+                if (it != current_label_map_.end()) {
+                    target = it->second;
+                }
+                pc = function.instructions.data() + target - 1;
             }
             break;
+        }
         default:
             break;
     }

--- a/src/backend/vm/ops/frames.cpp
+++ b/src/backend/vm/ops/frames.cpp
@@ -19,20 +19,30 @@ void RegisterVM::execute_frames(const LIR::LIR_Inst* pc) {
             break;
         case LIR::LIR_Op::FrameGetField:
             if (IS_PTR(registers[pc->a])) {
-                LmFrame* f = (LmFrame*)UNBOX_PTR(registers[pc->a]);
-                if (f && pc->b >= 0 && pc->b < f->field_count) {
-                    registers[pc->dst] = f->fields[pc->b];
+                ObjHeader* header = (ObjHeader*)UNBOX_PTR(registers[pc->a]);
+                if (header && header->type_id == TYPE_FRAME) {
+                    LmFrame* f = (LmFrame*)header;
+                    if (pc->b >= 0 && pc->b < f->field_count) {
+                        registers[pc->dst] = f->fields[pc->b];
+                    } else {
+                        registers[pc->dst] = VAL_NIL;
+                    }
                 } else {
-                    registers[pc->dst] = 0;
+                    registers[pc->dst] = VAL_NIL;
                 }
+            } else {
+                registers[pc->dst] = VAL_NIL;
             }
             break;
         case LIR::LIR_Op::FrameSetField:
             // pc->dst holds the frame pointer (container), pc->b holds the value.
             if (IS_PTR(registers[pc->dst])) {
-                LmFrame* f = (LmFrame*)UNBOX_PTR(registers[pc->dst]);
-                if (f && pc->a >= 0 && pc->a < f->field_count) {
-                    f->fields[pc->a] = registers[pc->b];
+                ObjHeader* header = (ObjHeader*)UNBOX_PTR(registers[pc->dst]);
+                if (header && header->type_id == TYPE_FRAME) {
+                    LmFrame* f = (LmFrame*)header;
+                    if (pc->a >= 0 && pc->a < f->field_count) {
+                        f->fields[pc->a] = registers[pc->b];
+                    }
                 }
             }
             break;
@@ -41,9 +51,14 @@ void RegisterVM::execute_frames(const LIR::LIR_Inst* pc) {
             // (the runtime helpers are also non-atomic underneath; the
             // distinction exists for future memory-model work).
             if (IS_PTR(registers[pc->a])) {
-                LmFrame* f = (LmFrame*)UNBOX_PTR(registers[pc->a]);
-                if (f && pc->b >= 0 && pc->b < f->field_count) {
-                    registers[pc->dst] = lm_frame_get_field_atomic(f, (int)pc->b);
+                ObjHeader* header = (ObjHeader*)UNBOX_PTR(registers[pc->a]);
+                if (header && header->type_id == TYPE_FRAME) {
+                    LmFrame* f = (LmFrame*)header;
+                    if (pc->b >= 0 && pc->b < f->field_count) {
+                        registers[pc->dst] = lm_frame_get_field_atomic(f, (int)pc->b);
+                    } else {
+                        registers[pc->dst] = VAL_NIL;
+                    }
                 } else {
                     registers[pc->dst] = VAL_NIL;
                 }
@@ -53,25 +68,34 @@ void RegisterVM::execute_frames(const LIR::LIR_Inst* pc) {
             break;
         case LIR::LIR_Op::FrameSetFieldAtomic:
             if (IS_PTR(registers[pc->dst])) {
-                LmFrame* f = (LmFrame*)UNBOX_PTR(registers[pc->dst]);
-                if (f && pc->a >= 0 && pc->a < f->field_count) {
-                    lm_frame_set_field_atomic(f, (int)pc->a, registers[pc->b]);
+                ObjHeader* header = (ObjHeader*)UNBOX_PTR(registers[pc->dst]);
+                if (header && header->type_id == TYPE_FRAME) {
+                    LmFrame* f = (LmFrame*)header;
+                    if (pc->a >= 0 && pc->a < f->field_count) {
+                        lm_frame_set_field_atomic(f, (int)pc->a, registers[pc->b]);
+                    }
                 }
             }
             break;
         case LIR::LIR_Op::FrameFieldAtomicAdd:
             if (IS_PTR(registers[pc->a])) {
-                LmFrame* f = (LmFrame*)UNBOX_PTR(registers[pc->a]);
-                if (f && pc->b >= 0 && pc->b < f->field_count) {
-                    lm_frame_field_atomic_add(f, (int)pc->b, registers[pc->dst]);
+                ObjHeader* header = (ObjHeader*)UNBOX_PTR(registers[pc->a]);
+                if (header && header->type_id == TYPE_FRAME) {
+                    LmFrame* f = (LmFrame*)header;
+                    if (pc->b >= 0 && pc->b < f->field_count) {
+                        lm_frame_field_atomic_add(f, (int)pc->b, registers[pc->dst]);
+                    }
                 }
             }
             break;
         case LIR::LIR_Op::FrameFieldAtomicSub:
             if (IS_PTR(registers[pc->a])) {
-                LmFrame* f = (LmFrame*)UNBOX_PTR(registers[pc->a]);
-                if (f && pc->b >= 0 && pc->b < f->field_count) {
-                    lm_frame_field_atomic_sub(f, (int)pc->b, registers[pc->dst]);
+                ObjHeader* header = (ObjHeader*)UNBOX_PTR(registers[pc->a]);
+                if (header && header->type_id == TYPE_FRAME) {
+                    LmFrame* f = (LmFrame*)header;
+                    if (pc->b >= 0 && pc->b < f->field_count) {
+                        lm_frame_field_atomic_sub(f, (int)pc->b, registers[pc->dst]);
+                    }
                 }
             }
             break;

--- a/src/backend/vm/ops/vm_cast.cpp
+++ b/src/backend/vm/ops/vm_cast.cpp
@@ -48,6 +48,8 @@ void RegisterVM::execute_cast(const LIR::LIR_Inst* pc) {
                 registers[pc->dst] = make_float(as_float(val));
             } else if (pc->result_type == LIR::Type::Bool) {
                 registers[pc->dst] = to_bool(val) ? VAL_TRUE : VAL_FALSE;
+            } else {
+                registers[pc->dst] = val;
             }
             break;
         }

--- a/src/backend/vm/register.cpp
+++ b/src/backend/vm/register.cpp
@@ -136,6 +136,25 @@ void RegisterVM::execute_instructions(const LIR::LIR_Function& function, uint64_
     size_t needed_registers = required_register_count(function);
     if (registers.size() < needed_registers) registers.resize(needed_registers, VAL_NIL);
 
+    std::unordered_map<uint32_t, size_t> saved_label_map = current_label_map_;
+    current_label_map_.clear();
+    for (size_t i = 0; i < function.instructions.size(); ++i) {
+        if (function.instructions[i].op == LIR::LIR_Op::Label) {
+            current_label_map_[function.instructions[i].dst] = i;
+        }
+    }
+
+    struct LabelMapGuard {
+        std::unordered_map<uint32_t, size_t>& map;
+        std::unordered_map<uint32_t, size_t> saved;
+        LabelMapGuard(std::unordered_map<uint32_t, size_t>& m, std::unordered_map<uint32_t, size_t> s)
+            : map(m), saved(s) {}
+        ~LabelMapGuard() {
+            map = saved;
+        }
+    };
+    LabelMapGuard label_map_guard(current_label_map_, saved_label_map);
+
     const LIR::LIR_Inst* instructions_ptr = function.instructions.data();
     const LIR::LIR_Inst* pc = instructions_ptr + start_pc;
     const LIR::LIR_Inst* end_ptr = instructions_ptr + (end_pc < function.instructions.size() ? end_pc : function.instructions.size());

--- a/src/backend/vm/register.hh
+++ b/src/backend/vm/register.hh
@@ -159,6 +159,7 @@ private:
     std::unordered_map<int64_t, ErrorInfo> error_table;
     
     const LIR::LIR_Function* current_function_ = nullptr;
+    std::unordered_map<uint32_t, size_t> current_label_map_;
     std::unordered_map<std::string, RegisterValue> globals_;
     std::unique_ptr<TypeSystem> type_system;
     

--- a/src/backend/vm/resource_manager.cpp
+++ b/src/backend/vm/resource_manager.cpp
@@ -80,6 +80,9 @@ const char* register_value_to_cstr(RegisterValue val) {
         LmBox* box = (LmBox*)h;
         if (box->type == LM_BOX_STRING) return (const char*)box->value.as_ptr;
     }
+    if (h->type_id == TYPE_STRING) {
+        return (const char*)h + sizeof(ObjHeader);
+    }
     return nullptr;
 }
 

--- a/src/lir/generator/core.cpp
+++ b/src/lir/generator/core.cpp
@@ -175,14 +175,22 @@ void Generator::generate_function(LM::Frontend::AST::FunctionDeclaration& fn) {
     // Register regular parameters
     for (size_t i = 0; i < fn.params.size(); ++i) {
         bind_variable(fn.params[i].first, static_cast<Reg>(i));
-        set_register_type(static_cast<Reg>(i), nullptr);
+        TypePtr lang_type = nullptr;
+        if (fn.params[i].second) {
+            lang_type = convert_ast_type_to_lir_type(fn.params[i].second);
+        }
+        set_register_language_type(static_cast<Reg>(i), lang_type);
     }
     
     // Register optional parameters
     for (size_t i = 0; i < fn.optionalParams.size(); ++i) {
         size_t reg_index = fn.params.size() + i;
         bind_variable(fn.optionalParams[i].first, static_cast<Reg>(reg_index));
-        set_register_type(static_cast<Reg>(reg_index), nullptr);
+        TypePtr lang_type = nullptr;
+        if (fn.optionalParams[i].second.first) {
+            lang_type = convert_ast_type_to_lir_type(fn.optionalParams[i].second.first);
+        }
+        set_register_language_type(static_cast<Reg>(reg_index), lang_type);
     }
     
     // Register environment parameter if this is a closure
@@ -216,12 +224,20 @@ void Generator::generate_function(LM::Frontend::AST::FunctionDeclaration& fn) {
         LIRParameter lir_param;
         lir_param.name = param.first;
         lir_param.type = Type::I64;
+        if (param.second) {
+            auto lang_type = convert_ast_type_to_lir_type(param.second);
+            lir_param.type = language_type_to_abi_type(lang_type);
+        }
         params.push_back(lir_param);
     }
     for (const auto& optional_param : fn.optionalParams) {
         LIRParameter lir_param;
         lir_param.name = optional_param.first;
         lir_param.type = Type::I64;
+        if (optional_param.second.first) {
+            auto lang_type = convert_ast_type_to_lir_type(optional_param.second.first);
+            lir_param.type = language_type_to_abi_type(lang_type);
+        }
         params.push_back(lir_param);
     }
     
@@ -960,6 +976,19 @@ bool Generator::validate_cfg() {
 std::shared_ptr<::Type> Generator::convert_ast_type_to_lir_type(const std::shared_ptr<LM::Frontend::AST::TypeAnnotation>& ast_type) {
     if (!ast_type) {
         return nullptr;
+    }
+
+    if (ast_type->isList) {
+        return std::make_shared<::Type>(::TypeTag::List);
+    }
+    if (ast_type->isDict) {
+        return std::make_shared<::Type>(::TypeTag::Dict);
+    }
+    if (ast_type->isTuple) {
+        return std::make_shared<::Type>(::TypeTag::Tuple);
+    }
+    if (ast_type->isUnion) {
+        return std::make_shared<::Type>(::TypeTag::Union);
     }
     
     // Convert AST type to LIR type

--- a/src/lir/generator/oop.cpp
+++ b/src/lir/generator/oop.cpp
@@ -86,6 +86,10 @@ void Generator::lower_trait_method(const std::string& trait_name, LM::Frontend::
         LIRParameter lir_param;
         lir_param.name = param.first;
         lir_param.type = Type::I64;
+        if (param.second) {
+            auto lang_type = convert_ast_type_to_lir_type(param.second);
+            lir_param.type = language_type_to_abi_type(lang_type);
+        }
         params.push_back(lir_param);
     }
     
@@ -154,14 +158,22 @@ void Generator::lower_frame_method(const std::string& frame_name, LM::Frontend::
     for (size_t i = 0; i < method.parameters.size(); ++i) {
         size_t reg_index = i + 1; // +1 for 'this'
         bind_variable(method.parameters[i].first, static_cast<Reg>(reg_index));
-        set_register_type(static_cast<Reg>(reg_index), nullptr);
+        TypePtr lang_type = nullptr;
+        if (method.parameters[i].second) {
+            lang_type = convert_ast_type_to_lir_type(method.parameters[i].second);
+        }
+        set_register_language_type(static_cast<Reg>(reg_index), lang_type);
     }
     
     // Register optional parameters
     for (size_t i = 0; i < method.optionalParams.size(); ++i) {
         size_t reg_index = method.parameters.size() + i + 1; // +1 for 'this'
         bind_variable(method.optionalParams[i].first, static_cast<Reg>(reg_index));
-        set_register_type(static_cast<Reg>(reg_index), nullptr);
+        TypePtr lang_type = nullptr;
+        if (method.optionalParams[i].second.first) {
+            lang_type = convert_ast_type_to_lir_type(method.optionalParams[i].second.first);
+        }
+        set_register_language_type(static_cast<Reg>(reg_index), lang_type);
     }
     
     // Emit method body
@@ -208,12 +220,20 @@ void Generator::lower_frame_method(const std::string& frame_name, LM::Frontend::
         lir_param.name = param.first;
         // Convert type - for now use I64 as default
         lir_param.type = Type::I64;
+        if (param.second) {
+            auto lang_type = convert_ast_type_to_lir_type(param.second);
+            lir_param.type = language_type_to_abi_type(lang_type);
+        }
         params.push_back(lir_param);
     }
     for (const auto& optional_param : method.optionalParams) {
         LIRParameter lir_param;
         lir_param.name = optional_param.first;
         lir_param.type = Type::I64;
+        if (optional_param.second.first) {
+            auto lang_type = convert_ast_type_to_lir_type(optional_param.second.first);
+            lir_param.type = language_type_to_abi_type(lang_type);
+        }
         params.push_back(lir_param);
     }
     
@@ -269,14 +289,22 @@ void Generator::lower_frame_init_method(const std::string& frame_name, LM::Front
     for (size_t i = 0; i < init_method.parameters.size(); ++i) {
         size_t reg_index = i + 1; // +1 for 'this'
         bind_variable(init_method.parameters[i].first, static_cast<Reg>(reg_index));
-        set_register_type(static_cast<Reg>(reg_index), nullptr);
+        TypePtr lang_type = nullptr;
+        if (init_method.parameters[i].second) {
+            lang_type = convert_ast_type_to_lir_type(init_method.parameters[i].second);
+        }
+        set_register_language_type(static_cast<Reg>(reg_index), lang_type);
     }
     
     // Register optional init parameters
     for (size_t i = 0; i < init_method.optionalParams.size(); ++i) {
         size_t reg_index = init_method.parameters.size() + i + 1; // +1 for 'this'
         bind_variable(init_method.optionalParams[i].first, static_cast<Reg>(reg_index));
-        set_register_type(static_cast<Reg>(reg_index), nullptr);
+        TypePtr lang_type = nullptr;
+        if (init_method.optionalParams[i].second.first) {
+            lang_type = convert_ast_type_to_lir_type(init_method.optionalParams[i].second.first);
+        }
+        set_register_language_type(static_cast<Reg>(reg_index), lang_type);
     }
     
     // Emit init method body
@@ -323,12 +351,20 @@ void Generator::lower_frame_init_method(const std::string& frame_name, LM::Front
         lir_param.name = param.first;
         // Convert type - for now use I64 as default
         lir_param.type = Type::I64;
+        if (param.second) {
+            auto lang_type = convert_ast_type_to_lir_type(param.second);
+            lir_param.type = language_type_to_abi_type(lang_type);
+        }
         params.push_back(lir_param);
     }
     for (const auto& optional_param : init_method.optionalParams) {
         LIRParameter lir_param;
         lir_param.name = optional_param.first;
         lir_param.type = Type::I64;
+        if (optional_param.second.first) {
+            auto lang_type = convert_ast_type_to_lir_type(optional_param.second.first);
+            lir_param.type = language_type_to_abi_type(lang_type);
+        }
         params.push_back(lir_param);
     }
     


### PR DESCRIPTION
Fixes and stabilizes all LIR generator parameter types, collection types, VM control flow jumps, frame field access safety, and cast fallbacks to enable full execution of standard library I/O and collections tests.

---
*PR created automatically by Jules for task [18048946353035210178](https://jules.google.com/task/18048946353035210178) started by @netesy*