### PR TITLE
Fix standard library submodule type resolution

### DIFF
--- a/src/frontend/type_checker/core.cpp
+++ b/src/frontend/type_checker/core.cpp
@@ -34,9 +34,14 @@ bool TypeChecker::check_program(std::shared_ptr<LM::Frontend::AST::Program> prog
 
     // PASS -1: Basic Type Discovery (Pre-registration)
     auto register_custom_type = [&](const std::string& name, const std::shared_ptr<LM::Frontend::AST::Statement>& stmt) {
+        std::string registered_name = name;
+        if (!current_module_name.empty() && name.find('.') == std::string::npos) {
+            registered_name = current_module_name + "." + name;
+        }
+
         if (auto enum_decl = std::dynamic_pointer_cast<LM::Frontend::AST::EnumDeclaration>(stmt)) {
             EnumType enumTypeInfo;
-            enumTypeInfo.name = name;
+            enumTypeInfo.name = registered_name;
             for (const auto& variant : enum_decl->variants) {
                 std::vector<TypePtr> associated;
                 for (const auto& t : variant.second) {
@@ -51,11 +56,11 @@ bool TypeChecker::check_program(std::shared_ptr<LM::Frontend::AST::Program> prog
                 enumTypeInfo.addVariant(variant.first, associated);
             }
             TypePtr enumType = std::make_shared<::Type>(TypeTag::Enum, enumTypeInfo);
-            type_system.addUserDefinedType(name, enumType);
+            type_system.addUserDefinedType(registered_name, enumType);
 
             // Register variants in global scope (qualified only) and track ownership
             for (const auto& variant : enum_decl->variants) {
-                std::string qualified = name + "." + variant.first;
+                std::string qualified = registered_name + "." + variant.first;
                 variant_owners[variant.first].push_back(enumType);
                 
                 if (variant.second.empty()) {
@@ -77,9 +82,9 @@ bool TypeChecker::check_program(std::shared_ptr<LM::Frontend::AST::Program> prog
                 }
             }
         } else if (auto type_decl = std::dynamic_pointer_cast<LM::Frontend::AST::TypeDeclaration>(stmt)) {
-            type_system.addUserDefinedType(name, type_system.ANY_TYPE);
+            type_system.addUserDefinedType(registered_name, type_system.ANY_TYPE);
         } else if (auto frame_decl = std::dynamic_pointer_cast<LM::Frontend::AST::FrameDeclaration>(stmt)) {
-            type_system.addUserDefinedType(name, type_system.createFrameType(name));
+            type_system.addUserDefinedType(registered_name, type_system.createFrameType(registered_name));
         }
     };
 
@@ -98,6 +103,11 @@ bool TypeChecker::check_program(std::shared_ptr<LM::Frontend::AST::Program> prog
     // PASS 0: Module Resolution and Type Checking
     if (is_root) {
         auto& manager = ModuleManager::getInstance();
+        for (auto& [path, module] : manager.get_all_modules()) {
+            if (module) {
+                module->is_checked = false;
+            }
+        }
         // manager.clear(); // Removed to prevent infinite recursion
         // manager.resolve_all(program, "root"); // Handled by factory or initial call
         if (manager.has_circular_dependencies()) {
@@ -117,6 +127,11 @@ bool TypeChecker::check_program(std::shared_ptr<LM::Frontend::AST::Program> prog
                 module->is_checked = true;
                 TypeChecker checker(this->type_system, this->symbol_db_);
                 checker.is_root = false; // Submodules are not root checkers
+                checker.current_module_name = path; // Set module namespace
+                checker.frame_declarations = this->frame_declarations;
+                checker.trait_declarations = this->trait_declarations;
+                checker.function_signatures = this->function_signatures;
+                checker.variable_types = this->variable_types;
                 TypeCheckerFactory::register_builtin_functions(checker);
                 checker.set_source_context(module->source, module->path);
                 if (!checker.check_program(module->ast)) {
@@ -132,24 +147,27 @@ bool TypeChecker::check_program(std::shared_ptr<LM::Frontend::AST::Program> prog
                 }
 
                 for (const auto& [name, info] : checker.frame_declarations) {
-                    this->frame_declarations[name] = info;
-                    if (!name.starts_with(path + ".")) {
+                    if (name.starts_with(path + ".")) {
+                        this->frame_declarations[name] = info;
+                    } else {
                         FrameInfo info_copy = info;
                         info_copy.name = path + "." + name;
                         this->frame_declarations[path + "." + name] = info_copy;
                     }
                 }
                 for (const auto& [name, info] : checker.trait_declarations) {
-                    this->trait_declarations[name] = info;
-                    if (!name.starts_with(path + ".")) {
+                    if (name.starts_with(path + ".")) {
+                        this->trait_declarations[name] = info;
+                    } else {
                         TraitInfo info_copy = info;
                         info_copy.name = path + "." + name;
                         this->trait_declarations[path + "." + name] = info_copy;
                     }
                 }
                 for (const auto& [name, sig] : checker.function_signatures) {
-                    this->function_signatures[name] = sig;
-                    if (!name.starts_with(path + ".")) {
+                    if (name.starts_with(path + ".")) {
+                        this->function_signatures[name] = sig;
+                    } else {
                         FunctionSignature sig_copy = sig;
                         sig_copy.name = path + "." + name;
                         this->function_signatures[path + "." + name] = sig_copy;
@@ -157,8 +175,9 @@ bool TypeChecker::check_program(std::shared_ptr<LM::Frontend::AST::Program> prog
                 }
                 for (const auto& [name, type] : checker.variable_types) {
                     if (type != nullptr) {
-                        this->variable_types[name] = type;
-                        if (!name.starts_with(path + ".")) {
+                        if (name.starts_with(path + ".")) {
+                            this->variable_types[name] = type;
+                        } else {
                             this->variable_types[path + "." + name] = type;
                         }
                     }
@@ -201,10 +220,39 @@ bool TypeChecker::check_program(std::shared_ptr<LM::Frontend::AST::Program> prog
     }
 
     // PASS 2: Signature Resolution (including inlined symbols)
-    auto resolve_sig = [&](const std::string& name, const std::shared_ptr<LM::Frontend::AST::Statement>& stmt) {
+    auto resolve_sig = [&](const std::string& name, const std::shared_ptr<LM::Frontend::AST::Statement>& stmt, bool is_imported = false) {
+        std::string registered_name = name;
+        if (!is_imported && !current_module_name.empty() && name.find('.') == std::string::npos) {
+            registered_name = current_module_name + "." + name;
+        }
+
+        std::string frame_module = current_module_name;
+        if (is_imported) {
+            size_t last_dot_idx = name.find_last_of('.');
+            if (last_dot_idx != std::string::npos) {
+                std::string prefix = name.substr(0, last_dot_idx);
+                if (import_aliases.count(prefix)) {
+                    frame_module = import_aliases[prefix];
+                } else {
+                    frame_module = prefix;
+                }
+            }
+        }
+        struct ModuleNameGuard {
+            std::string& current_module_name;
+            std::string old_module_name;
+            ModuleNameGuard(std::string& name, const std::string& new_name)
+                : current_module_name(name), old_module_name(name) {
+                current_module_name = new_name;
+            }
+            ~ModuleNameGuard() {
+                current_module_name = old_module_name;
+            }
+        } guard(current_module_name, frame_module);
+
         if (auto frame_decl = std::dynamic_pointer_cast<LM::Frontend::AST::FrameDeclaration>(stmt)) {
             TypeSystem::FrameInfo info;
-            info.name = name;
+            info.name = registered_name;
             info.declaration = frame_decl;
             info.implements = frame_decl->implements;
             info.hasInit = (frame_decl->init != nullptr);
@@ -219,8 +267,8 @@ bool TypeChecker::check_program(std::shared_ptr<LM::Frontend::AST::Program> prog
             }
             info.totalFieldSize = offset;
 
-            auto& fd = frame_declarations[name];
-            fd.name = name;
+            auto& fd = frame_declarations[registered_name];
+            fd.name = registered_name;
             fd.declaration = frame_decl;
             fd.fields = info.fields;
             fd.field_has_default.clear();
@@ -229,50 +277,54 @@ bool TypeChecker::check_program(std::shared_ptr<LM::Frontend::AST::Program> prog
             }
 
             if (frame_decl->init) {
-                std::string init_name = name + ".init";
+                std::string init_name = registered_name + ".init";
                 FunctionSignature sig;
                 sig.name = init_name;
                 sig.declaration = frame_decl->init;
                 sig.return_type = type_system.NIL_TYPE;
-                sig.param_types.push_back(type_system.createFrameType(name));
+                sig.param_types.push_back(type_system.createFrameType(registered_name));
                 for (const auto& p : frame_decl->init->parameters) sig.param_types.push_back(resolve_type_annotation(p.second));
                 for (const auto& op : frame_decl->init->optionalParams) sig.param_types.push_back(resolve_type_annotation(op.second.first));
                 function_signatures[init_name] = sig;
             }
             for (const auto& m : frame_decl->methods) {
-                std::string m_name = name + "." + m->name;
+                std::string m_name = registered_name + "." + m->name;
                 FunctionSignature sig;
                 sig.name = m_name;
                 sig.declaration = m;
                 sig.return_type = m->returnType ? resolve_type_annotation(m->returnType) : type_system.NIL_TYPE;
-                sig.param_types.push_back(type_system.createFrameType(name));
+                sig.param_types.push_back(type_system.createFrameType(registered_name));
                 for (const auto& p : m->parameters) sig.param_types.push_back(resolve_type_annotation(p.second));
                 for (const auto& op : m->optionalParams) sig.param_types.push_back(resolve_type_annotation(op.second.first));
                 function_signatures[m_name] = sig;
                 info.methodSignatures[m->name] = sig.return_type;
             }
             if (frame_decl->deinit) {
-                std::string deinit_name = name + ".deinit";
+                std::string deinit_name = registered_name + ".deinit";
                 FunctionSignature sig;
                 sig.name = deinit_name;
                 sig.declaration = frame_decl->deinit;
                 sig.return_type = type_system.NIL_TYPE;
-                sig.param_types.push_back(type_system.createFrameType(name));
+                sig.param_types.push_back(type_system.createFrameType(registered_name));
                 function_signatures[deinit_name] = sig;
             }
 
-            type_system.registerFrame(name, info);
-            frame_declarations[name].name = info.name;
-            frame_declarations[name].declaration = frame_decl;
-            frame_declarations[name].fields = info.fields;
+            type_system.registerFrame(registered_name, info);
+            frame_declarations[registered_name].name = info.name;
+            frame_declarations[registered_name].declaration = frame_decl;
+            frame_declarations[registered_name].fields = info.fields;
+            if (registered_name != name) {
+                type_system.registerFrame(name, info);
+                frame_declarations[name] = frame_declarations[registered_name];
+            }
 
         } else if (auto trait_decl = std::dynamic_pointer_cast<LM::Frontend::AST::TraitDeclaration>(stmt)) {
             TypeSystem::TraitInfo info;
-            info.name = name;
+            info.name = registered_name;
             info.declaration = trait_decl;
             info.extends = trait_decl->extends;
             for (const auto& m : trait_decl->methods) {
-                std::string m_name = name + "." + m->name;
+                std::string m_name = registered_name + "." + m->name;
                 FunctionSignature sig;
                 sig.name = m_name;
                 sig.return_type = m->returnType ? resolve_type_annotation(m->returnType.value()) : type_system.NIL_TYPE;
@@ -280,11 +332,17 @@ bool TypeChecker::check_program(std::shared_ptr<LM::Frontend::AST::Program> prog
                 for (const auto& p : m->params) sig.param_types.push_back(resolve_type_annotation(p.second));
                 function_signatures[m_name] = sig;
                 info.methodSignatures[m->name] = sig.return_type;
+                if (registered_name != name) {
+                    function_signatures[name + "." + m->name] = sig;
+                }
             }
-            type_system.registerTrait(name, info);
+            type_system.registerTrait(registered_name, info);
+            if (registered_name != name) {
+                type_system.registerTrait(name, info);
+            }
         } else if (auto func_decl = std::dynamic_pointer_cast<LM::Frontend::AST::FunctionDeclaration>(stmt)) {
             FunctionSignature sig;
-            sig.name = name;
+            sig.name = registered_name;
             if (func_decl->name == "main") {
                  sig.return_type = type_system.INT64_TYPE;
             } else {
@@ -301,7 +359,10 @@ bool TypeChecker::check_program(std::shared_ptr<LM::Frontend::AST::Program> prog
                 sig.param_types.push_back(resolve_type_annotation(op.second.first));
                 sig.optional_params.push_back(true);
             }
-            function_signatures[name] = sig;
+            function_signatures[registered_name] = sig;
+            if (registered_name != name) {
+                function_signatures[name] = sig;
+            }
             
             std::vector<std::string> param_names;
             std::vector<bool> has_defaults;
@@ -314,11 +375,18 @@ bool TypeChecker::check_program(std::shared_ptr<LM::Frontend::AST::Program> prog
                 has_defaults.push_back(op.second.second != nullptr);
             }
             TypePtr func_type = type_system.createFunctionType(param_names, sig.param_types, sig.return_type, has_defaults);
-            variable_types[name] = func_type;
-            declare_variable(name, func_type);
+            variable_types[registered_name] = func_type;
+            declare_variable(registered_name, func_type);
+            if (registered_name != name) {
+                variable_types[name] = func_type;
+                declare_variable(name, func_type);
+            }
         } else if (auto var_decl = std::dynamic_pointer_cast<LM::Frontend::AST::VarDeclaration>(stmt)) {
             TypePtr var_type = (var_decl->type && var_decl->type.value()) ? resolve_type_annotation(var_decl->type.value()) : type_system.ANY_TYPE;
-            declare_variable(name, var_type);
+            declare_variable(registered_name, var_type);
+            if (registered_name != name) {
+                declare_variable(name, var_type);
+            }
         } else if (auto enum_decl = std::dynamic_pointer_cast<LM::Frontend::AST::EnumDeclaration>(stmt)) {
             check_enum_declaration(enum_decl);
         } else if (auto type_decl = std::dynamic_pointer_cast<LM::Frontend::AST::TypeDeclaration>(stmt)) {
@@ -332,10 +400,10 @@ bool TypeChecker::check_program(std::shared_ptr<LM::Frontend::AST::Program> prog
         else if (auto trait = std::dynamic_pointer_cast<LM::Frontend::AST::TraitDeclaration>(stmt)) name = trait->name;
         else if (auto func = std::dynamic_pointer_cast<LM::Frontend::AST::FunctionDeclaration>(stmt)) name = func->name;
         else if (auto enm = std::dynamic_pointer_cast<LM::Frontend::AST::EnumDeclaration>(stmt)) name = enm->name;
-        if (!name.empty()) resolve_sig(name, stmt);
+        if (!name.empty()) resolve_sig(name, stmt, false);
     }
     for (const auto& [name, stmt] : program->imported_symbols) {
-        resolve_sig(name, stmt);
+        resolve_sig(name, stmt, true);
     }
 
     // PASS 2.5: Global Scope Population

--- a/src/frontend/type_checker/declarations.cpp
+++ b/src/frontend/type_checker/declarations.cpp
@@ -636,6 +636,9 @@ TypePtr TypeChecker::check_import_statement(std::shared_ptr<LM::Frontend::AST::I
     frame_declarations[alias] = alias_info;
     declare_variable(alias, type_system.createFrameType(alias));
     
+    std::string prev_module_name = current_module_name;
+    current_module_name = import_stmt->modulePath;
+
     // Register all symbols from the module
     for (const auto& stmt : module->ast->statements) {
         std::string name;
@@ -643,6 +646,8 @@ TypePtr TypeChecker::check_import_statement(std::shared_ptr<LM::Frontend::AST::I
         else if (auto fr = std::dynamic_pointer_cast<LM::Frontend::AST::FrameDeclaration>(stmt)) name = fr->name;
         else if (auto v = std::dynamic_pointer_cast<LM::Frontend::AST::VarDeclaration>(stmt)) name = v->name;
         else if (auto t = std::dynamic_pointer_cast<LM::Frontend::AST::TraitDeclaration>(stmt)) name = t->name;
+        else if (auto td = std::dynamic_pointer_cast<LM::Frontend::AST::TypeDeclaration>(stmt)) name = td->name;
+        else if (auto ed = std::dynamic_pointer_cast<LM::Frontend::AST::EnumDeclaration>(stmt)) name = ed->name;
         
         // Import all public symbols if no filter, or only filtered symbols
         bool should_import = symbols_to_import.empty() || symbols_to_import.count(name);
@@ -666,31 +671,40 @@ TypePtr TypeChecker::check_import_statement(std::shared_ptr<LM::Frontend::AST::I
                 const std::string& qname = target.first;
                 
                 if (auto f = std::dynamic_pointer_cast<LM::Frontend::AST::FunctionDeclaration>(stmt)) {
-                    FunctionSignature sig; 
-                    sig.name = qname; 
-                    sig.declaration = f;
-                    sig.return_type = (f->name == "main") ? type_system.INT64_TYPE : (f->returnType.has_value() 
-                        ? resolve_type_annotation(f->returnType.value()) 
-                        : type_system.ANY_TYPE);
-                    sig.can_fail = f->canFail || f->throws;
-                    sig.error_types = f->declaredErrorTypes;
-                    
+                    FunctionSignature sig;
                     std::vector<std::string> param_names;
                     std::vector<bool> has_defaults;
-                    
                     for (const auto& p : f->params) {
-                        sig.param_types.push_back(p.second ? resolve_type_annotation(p.second) : type_system.ANY_TYPE);
-                        sig.optional_params.push_back(false);
-                        sig.has_default_values.push_back(false);
                         param_names.push_back(p.first);
                         has_defaults.push_back(false);
                     }
                     for (const auto& op : f->optionalParams) {
-                        sig.param_types.push_back(op.second.first ? resolve_type_annotation(op.second.first) : type_system.ANY_TYPE);
-                        sig.optional_params.push_back(true);
-                        sig.has_default_values.push_back(op.second.second != nullptr);
                         param_names.push_back(op.first);
                         has_defaults.push_back(op.second.second != nullptr);
+                    }
+
+                    if (function_signatures.count(full_path_base)) {
+                        sig = function_signatures[full_path_base];
+                        sig.name = qname;
+                    } else {
+                        sig.name = qname;
+                        sig.declaration = f;
+                        sig.return_type = (f->name == "main") ? type_system.INT64_TYPE : (f->returnType.has_value()
+                            ? resolve_type_annotation(f->returnType.value())
+                            : type_system.ANY_TYPE);
+                        sig.can_fail = f->canFail || f->throws;
+                        sig.error_types = f->declaredErrorTypes;
+
+                        for (const auto& p : f->params) {
+                            sig.param_types.push_back(p.second ? resolve_type_annotation(p.second) : type_system.ANY_TYPE);
+                            sig.optional_params.push_back(false);
+                            sig.has_default_values.push_back(false);
+                        }
+                        for (const auto& op : f->optionalParams) {
+                            sig.param_types.push_back(op.second.first ? resolve_type_annotation(op.second.first) : type_system.ANY_TYPE);
+                            sig.optional_params.push_back(true);
+                            sig.has_default_values.push_back(op.second.second != nullptr);
+                        }
                     }
                     
                     function_signatures[qname] = sig;
@@ -717,8 +731,6 @@ TypePtr TypeChecker::check_import_statement(std::shared_ptr<LM::Frontend::AST::I
                     // Create and register the frame type
                     TypePtr frame_type = type_system.createFrameType(qname);
                     type_system.addUserDefinedType(qname, frame_type);
-                    type_system.addUserDefinedType(full_path_base, frame_type);
-                    type_system.addUserDefinedType(alias + "." + name, frame_type);
                     declare_variable(qname, frame_type);
                     
                     // Register in imported symbols so LIR generator can find it
@@ -727,45 +739,57 @@ TypePtr TypeChecker::check_import_statement(std::shared_ptr<LM::Frontend::AST::I
                     // Register frame methods (e.g. io.File.read)
                     for (const auto& method : fr->methods) {
                         std::string m_name = qname + "." + method->name;
-                        FunctionSignature sig; 
-                        sig.name = m_name; 
-                        sig.declaration = method;
-                        sig.return_type = method->returnType ? resolve_type_annotation(method->returnType) : type_system.NIL_TYPE;
-                        sig.param_types.push_back(type_system.createFrameType(qname)); // 'this'
-                        sig.optional_params.push_back(false);
-                        sig.has_default_values.push_back(false);
-                        
-                        for (const auto& p : method->parameters) {
-                             sig.param_types.push_back(p.second ? resolve_type_annotation(p.second) : type_system.ANY_TYPE);
-                             sig.optional_params.push_back(false);
-                             sig.has_default_values.push_back(false);
-                        }
-                        for (const auto& op : method->optionalParams) {
-                             sig.param_types.push_back(op.second.first ? resolve_type_annotation(op.second.first) : type_system.ANY_TYPE);
-                             sig.optional_params.push_back(true);
-                             sig.has_default_values.push_back(op.second.second != nullptr);
+                        std::string full_method_path = import_stmt->modulePath + "." + name + "." + method->name;
+                        FunctionSignature sig;
+                        if (function_signatures.count(full_method_path)) {
+                            sig = function_signatures[full_method_path];
+                            sig.name = m_name;
+                        } else {
+                            sig.name = m_name;
+                            sig.declaration = method;
+                            sig.return_type = method->returnType ? resolve_type_annotation(method->returnType) : type_system.NIL_TYPE;
+                            sig.param_types.push_back(type_system.createFrameType(qname)); // 'this'
+                            sig.optional_params.push_back(false);
+                            sig.has_default_values.push_back(false);
+
+                            for (const auto& p : method->parameters) {
+                                 sig.param_types.push_back(p.second ? resolve_type_annotation(p.second) : type_system.ANY_TYPE);
+                                 sig.optional_params.push_back(false);
+                                 sig.has_default_values.push_back(false);
+                            }
+                            for (const auto& op : method->optionalParams) {
+                                 sig.param_types.push_back(op.second.first ? resolve_type_annotation(op.second.first) : type_system.ANY_TYPE);
+                                 sig.optional_params.push_back(true);
+                                 sig.has_default_values.push_back(op.second.second != nullptr);
+                            }
                         }
                         function_signatures[m_name] = sig;
                     }
                     if (fr->init) {
                         std::string init_name = qname + ".init";
-                        FunctionSignature sig; 
-                        sig.name = init_name; 
-                        sig.declaration = fr->init;
-                        sig.return_type = type_system.createFrameType(qname);
-                        sig.param_types.push_back(type_system.createFrameType(qname)); // 'this'
-                        sig.optional_params.push_back(false);
-                        sig.has_default_values.push_back(false);
-                        
-                        for (const auto& p : fr->init->parameters) {
-                             sig.param_types.push_back(p.second ? resolve_type_annotation(p.second) : type_system.ANY_TYPE);
-                             sig.optional_params.push_back(false);
-                             sig.has_default_values.push_back(false);
-                        }
-                        for (const auto& op : fr->init->optionalParams) {
-                             sig.param_types.push_back(op.second.first ? resolve_type_annotation(op.second.first) : type_system.ANY_TYPE);
-                             sig.optional_params.push_back(true);
-                             sig.has_default_values.push_back(op.second.second != nullptr);
+                        std::string full_init_path = import_stmt->modulePath + "." + name + ".init";
+                        FunctionSignature sig;
+                        if (function_signatures.count(full_init_path)) {
+                            sig = function_signatures[full_init_path];
+                            sig.name = init_name;
+                        } else {
+                            sig.name = init_name;
+                            sig.declaration = fr->init;
+                            sig.return_type = type_system.createFrameType(qname);
+                            sig.param_types.push_back(type_system.createFrameType(qname)); // 'this'
+                            sig.optional_params.push_back(false);
+                            sig.has_default_values.push_back(false);
+
+                            for (const auto& p : fr->init->parameters) {
+                                 sig.param_types.push_back(p.second ? resolve_type_annotation(p.second) : type_system.ANY_TYPE);
+                                 sig.optional_params.push_back(false);
+                                 sig.has_default_values.push_back(false);
+                            }
+                            for (const auto& op : fr->init->optionalParams) {
+                                 sig.param_types.push_back(op.second.first ? resolve_type_annotation(op.second.first) : type_system.ANY_TYPE);
+                                 sig.optional_params.push_back(true);
+                                 sig.has_default_values.push_back(op.second.second != nullptr);
+                            }
                         }
                         function_signatures[init_name] = sig;
                     }
@@ -787,8 +811,6 @@ TypePtr TypeChecker::check_import_statement(std::shared_ptr<LM::Frontend::AST::I
                     }
                     trait_type->extra = trait_extra;
                     type_system.addUserDefinedType(qname, trait_type);
-                    type_system.addUserDefinedType(full_path_base, trait_type);
-                    type_system.addUserDefinedType(alias + "." + name, trait_type);
                     declare_variable(qname, trait_type);
                     
                     current_program_->imported_symbols[qname] = t;
@@ -812,10 +834,29 @@ TypePtr TypeChecker::check_import_statement(std::shared_ptr<LM::Frontend::AST::I
                         // Trait methods don't support optionalParams in AST yet, but we're ready
                         function_signatures[m_name] = sig;
                     }
+                } else if (auto td = std::dynamic_pointer_cast<LM::Frontend::AST::TypeDeclaration>(stmt)) {
+                    TypePtr underlying_type = type_system.getType(import_stmt->modulePath + "." + name);
+                    if (!underlying_type || underlying_type->tag == TypeTag::Nil) {
+                        underlying_type = type_system.getType(name);
+                    }
+                    if (underlying_type && underlying_type->tag != TypeTag::Nil) {
+                        type_system.registerTypeAlias(qname, underlying_type);
+                        type_system.addUserDefinedType(qname, underlying_type);
+                    }
+                } else if (auto ed = std::dynamic_pointer_cast<LM::Frontend::AST::EnumDeclaration>(stmt)) {
+                    TypePtr enum_type = type_system.getType(import_stmt->modulePath + "." + name);
+                    if (!enum_type || enum_type->tag == TypeTag::Nil) {
+                        enum_type = type_system.getType(name);
+                    }
+                    if (enum_type && enum_type->tag != TypeTag::Nil) {
+                        type_system.addUserDefinedType(qname, enum_type);
+                    }
                 }
             }
         }
     }
+
+    current_module_name = prev_module_name;
 
     import_stmt->inferred_type = type_system.NIL_TYPE;
     return type_system.NIL_TYPE;

--- a/src/frontend/type_checker/expressions.cpp
+++ b/src/frontend/type_checker/expressions.cpp
@@ -19,7 +19,11 @@ TypePtr TypeChecker::check_expression(std::shared_ptr<LM::Frontend::AST::Express
     } else if (auto this_expr = std::dynamic_pointer_cast<LM::Frontend::AST::ThisExpr>(expr)) {
         // Handle 'this' reference in frame methods
         if (current_frame) {
-            type = type_system.createFrameType(current_frame->name);
+            std::string f_name = current_frame->name;
+            if (!current_module_name.empty() && f_name.find('.') == std::string::npos) {
+                f_name = current_module_name + "." + f_name;
+            }
+            type = type_system.createFrameType(f_name);
         } else {
             add_error("'this' can only be used inside frame methods", expr->line);
             type = type_system.ANY_TYPE;
@@ -685,21 +689,29 @@ TypePtr TypeChecker::check_call_expr(std::shared_ptr<LM::Frontend::AST::CallExpr
     
     // Check if callee is a variable (could be function or frame name)
     if (auto var_expr = std::dynamic_pointer_cast<LM::Frontend::AST::VariableExpr>(expr->callee)) {
+        std::string frame_name = var_expr->name;
+        if (frame_name.find('.') == std::string::npos && !current_module_name.empty()) {
+            std::string qual = current_module_name + "." + frame_name;
+            if (frame_declarations.count(qual)) {
+                frame_name = qual;
+            }
+        }
+
         // Check if it's a frame instantiation
-        auto frame_it = frame_declarations.find(var_expr->name);
+        auto frame_it = frame_declarations.find(frame_name);
         if (frame_it == frame_declarations.end()) {
             // Try lookup in imported symbols
-            auto it = current_program_->imported_symbols.find(var_expr->name);
+            auto it = current_program_->imported_symbols.find(frame_name);
             if (it != current_program_->imported_symbols.end()) {
                  if (std::dynamic_pointer_cast<LM::Frontend::AST::FrameDeclaration>(it->second)) {
-                     frame_it = frame_declarations.find(var_expr->name);
+                     frame_it = frame_declarations.find(frame_name);
                  }
             }
         }
 
         if (frame_it != frame_declarations.end()) {
             const FrameInfo& frame_info = frame_it->second;
-            std::string init_name = var_expr->name + ".init";
+            std::string init_name = frame_name + ".init";
             auto sig_it = function_signatures.find(init_name);
 
             // Validate named arguments against both init parameters AND fields
@@ -731,14 +743,14 @@ TypePtr TypeChecker::check_call_expr(std::shared_ptr<LM::Frontend::AST::CallExpr
                     TypePtr val_type = check_expression(value);
                     if (!is_type_compatible(target_type, val_type)) add_type_error(target_type->toString(), val_type->toString(), expr->line);
                 } else {
-                    add_error("Frame '" + var_expr->name + "' has no field or init parameter named '" + arg_name + "'", expr->line);
+                    add_error("Frame '" + frame_name + "' has no field or init parameter named '" + arg_name + "'", expr->line);
                 }
             }
 
             // Validate positional arguments (passing to init)
             if (!expr->arguments.empty() || sig_it != function_signatures.end()) {
                 if (sig_it == function_signatures.end()) {
-                    if (!expr->arguments.empty()) add_error("Frame '" + var_expr->name + "' has no init() method to accept positional arguments", expr->line);
+                    if (!expr->arguments.empty()) add_error("Frame '" + frame_name + "' has no init() method to accept positional arguments", expr->line);
                 } else {
                     std::vector<TypePtr> expected_params = sig_it->second.param_types;
                     if (!expected_params.empty()) expected_params.erase(expected_params.begin()); // skip 'this'
@@ -760,14 +772,14 @@ TypePtr TypeChecker::check_call_expr(std::shared_ptr<LM::Frontend::AST::CallExpr
                          // Only error if we actually HAVE positional arguments,
                          // otherwise let's assume it's direct field initialization if it matches.
                          if (!expr->arguments.empty()) {
-                             add_error("Frame '" + var_expr->name + "' init method requires " + std::to_string(required_count) + " arguments, but only " +
+                             add_error("Frame '" + frame_name + "' init method requires " + std::to_string(required_count) + " arguments, but only " +
                                       std::to_string(expr->arguments.size() + satisfied_by_named) + " were provided", expr->line);
                          }
                     }
                 }
             }
 
-            TypePtr frame_type = type_system.createFrameType(var_expr->name);
+            TypePtr frame_type = type_system.createFrameType(frame_name);
             expr->inferred_type = frame_type;
             return frame_type;
         }
@@ -823,9 +835,23 @@ TypePtr TypeChecker::check_call_expr(std::shared_ptr<LM::Frontend::AST::CallExpr
 
                 // 1. Check if it's a frame instantiation (e.g., test.Counter())
                 auto frame_it = frame_declarations.find(qualified_name);
+                std::string resolved_frame_name = qualified_name;
+                if (frame_it == frame_declarations.end()) {
+                    TypePtr alias_type = type_system.getType(qualified_name);
+                    if (alias_type && alias_type->tag != TypeTag::Nil) {
+                        TypePtr underlying = type_system.resolveTypeAlias(qualified_name);
+                        if (underlying && underlying->tag == TypeTag::Frame) {
+                            auto* fData = std::get_if<FrameType>(&underlying->extra);
+                            if (fData) {
+                                resolved_frame_name = fData->name;
+                                frame_it = frame_declarations.find(resolved_frame_name);
+                            }
+                        }
+                    }
+                }
                 if (frame_it != frame_declarations.end()) {
                     const FrameInfo& frame_info = frame_it->second;
-                    std::string init_name = qualified_name + ".init";
+                    std::string init_name = resolved_frame_name + ".init";
                     auto sig_it = function_signatures.find(init_name);
 
                     // Validate named arguments against both init parameters AND fields
@@ -888,7 +914,7 @@ TypePtr TypeChecker::check_call_expr(std::shared_ptr<LM::Frontend::AST::CallExpr
                         }
                     }
 
-                    TypePtr frame_type = type_system.createFrameType(qualified_name);
+                    TypePtr frame_type = type_system.createFrameType(resolved_frame_name);
                     expr->inferred_type = frame_type;
                     return frame_type;
                 }
@@ -1012,6 +1038,13 @@ TypePtr TypeChecker::check_call_expr(std::shared_ptr<LM::Frontend::AST::CallExpr
             
             // Look up the frame declaration
             auto frame_it = frame_declarations.find(frame_name);
+            if (frame_it == frame_declarations.end() && !current_module_name.empty()) {
+                std::string prefix = current_module_name + ".";
+                if (frame_name.starts_with(prefix)) {
+                    std::string unq = frame_name.substr(prefix.length());
+                    frame_it = frame_declarations.find(unq);
+                }
+            }
             if (frame_it == frame_declarations.end()) {
                 add_error("Unknown frame type: " + frame_name, expr->line);
                 return type_system.ANY_TYPE;
@@ -1334,6 +1367,13 @@ TypePtr TypeChecker::check_assign_expr(std::shared_ptr<LM::Frontend::AST::Assign
             
             // Look up the frame declaration
             auto frame_it = frame_declarations.find(frame_name);
+            if (frame_it == frame_declarations.end() && !current_module_name.empty()) {
+                std::string prefix = current_module_name + ".";
+                if (frame_name.starts_with(prefix)) {
+                    std::string unq = frame_name.substr(prefix.length());
+                    frame_it = frame_declarations.find(unq);
+                }
+            }
             if (frame_it == frame_declarations.end()) {
                 add_error("Unknown frame type: " + frame_name, expr->line);
                 TypePtr value_type = check_expression(expr->value);
@@ -1481,13 +1521,13 @@ TypePtr TypeChecker::check_member_expr(std::shared_ptr<LM::Frontend::AST::Member
                 std::string q_low = qname; for(char& c : q_low) c = std::tolower(c);
                 for (const auto& kv : variable_types) {
                     std::string k_low = kv.first; for(char& c : k_low) c = std::tolower(c);
-                    if (k_low == q_low) return kv.second;
+                    if (k_low == q_low) {
+                        return kv.second;
+                    }
                 }
                 return nullptr;
             };
             TypePtr res = find_member(alias + "." + member_name);
-            if (!res) res = find_member(member_name);
-            if (!res) for (const auto& kv : variable_types) if (kv.first.ends_with("." + member_name)) { res = kv.second; break; }
             if (res) { expr->inferred_type = res; return res; }
         }
     }
@@ -1567,6 +1607,12 @@ TypePtr TypeChecker::check_member_expr(std::shared_ptr<LM::Frontend::AST::Member
             if (member_type && member_type->tag != TypeTag::Nil) {
                 expr->inferred_type = member_type;
                 return member_type;
+            }
+            // Check for type alias
+            TypePtr alias_type = type_system.getType(qualified_name);
+            if (alias_type && alias_type->tag != TypeTag::Nil) {
+                expr->inferred_type = alias_type;
+                return alias_type;
             }
             // Check for functions
             if (function_signatures.count(qualified_name)) {
@@ -2113,6 +2159,12 @@ void TypeChecker::resolve_call_arguments(std::shared_ptr<LM::Frontend::AST::Call
     if (!expr) return;
 
     auto sig_it = function_signatures.find(qualified_name);
+    if (sig_it == function_signatures.end()) {
+        if (!current_module_name.empty()) {
+            std::string full_name = current_module_name + "." + qualified_name;
+            sig_it = function_signatures.find(full_name);
+        }
+    }
     if (sig_it == function_signatures.end()) return;
 
     std::vector<std::pair<std::string, std::shared_ptr<LM::Frontend::AST::TypeAnnotation>>> params;

--- a/src/frontend/type_checker/types.cpp
+++ b/src/frontend/type_checker/types.cpp
@@ -109,6 +109,13 @@ TypePtr TypeChecker::resolve_type_annotation(std::shared_ptr<LM::Frontend::AST::
             if (import_aliases.count(alias)) {
                 type_name = import_aliases[alias] + "." + member;
             }
+        } else if (!current_module_name.empty()) {
+            // Qualify unqualified local type names
+            std::string qual = current_module_name + "." + type_name;
+            TypePtr qual_type = type_system.getType(qual);
+            if (qual_type && qual_type->tag != TypeTag::Nil) {
+                type_name = qual;
+            }
         }
 
         // First try to get the base type from the type system (handles built-in types and aliases)
@@ -218,6 +225,16 @@ bool TypeChecker::is_type_compatible(TypePtr expected, TypePtr actual) {
         size_t dot = s.find_last_of(".");
         return (dot != std::string::npos) ? s.substr(dot+1) : s;
     };
+
+    if (expected->tag == TypeTag::Frame && actual->tag == TypeTag::Frame) {
+        auto* eData = std::get_if<FrameType>(&expected->extra);
+        auto* aData = std::get_if<FrameType>(&actual->extra);
+        if (eData && aData) {
+            if (get_base(eData->name) == get_base(aData->name)) {
+                return true;
+            }
+        }
+    }
 
     if (actual->tag == TypeTag::Frame && expected->tag == TypeTag::Trait) {
         auto* fData = std::get_if<FrameType>(&actual->extra);
@@ -630,7 +647,11 @@ void TypeChecker::validate_function_body_error_types(const std::shared_ptr<LM::F
         for (const auto& inferredError : inferredErrorTypes) {
             bool declared = false;
             for (const auto& declaredError : stmt->declaredErrorTypes) {
-                if (declaredError == inferredError) {
+                auto get_base = [](const std::string& s) {
+                    size_t last_dot = s.rfind('.');
+                    return (last_dot != std::string::npos) ? s.substr(last_dot + 1) : s;
+                };
+                if (get_base(declaredError) == get_base(inferredError)) {
                     declared = true;
                     break;
                 }
@@ -650,7 +671,7 @@ void TypeChecker::validate_function_body_error_types(const std::shared_ptr<LM::F
                             if (cleanName.rfind("Frame<", 0) == 0 && cleanName.back() == '>') {
                                 cleanName = cleanName.substr(6, cleanName.size() - 7);
                             }
-                            if (cleanName == inferredError) {
+                            if (get_base(cleanName) == get_base(inferredError)) {
                                 found_in_union = true;
                                 break;
                             }
@@ -783,7 +804,14 @@ bool TypeChecker::can_function_produce_error_type(const std::shared_ptr<LM::Fron
         if (returnStmt->value) {
             // Check if return expression can produce error type
             auto returnErrors = infer_expression_error_types(returnStmt->value);
-            return std::find(returnErrors.begin(), returnErrors.end(), errorType) != returnErrors.end();
+            auto get_base = [](const std::string& s) {
+                size_t last_dot = s.rfind('.');
+                return (last_dot != std::string::npos) ? s.substr(last_dot + 1) : s;
+            };
+            for (const auto& err : returnErrors) {
+                if (get_base(err) == get_base(errorType)) return true;
+            }
+            return false;
         }
     } else if (auto ifStmt = std::dynamic_pointer_cast<LM::Frontend::AST::IfStatement>(body)) {
         return can_function_produce_error_type(ifStmt->thenBranch, errorType) ||
@@ -791,7 +819,14 @@ bool TypeChecker::can_function_produce_error_type(const std::shared_ptr<LM::Fron
     } else if (auto exprStmt = std::dynamic_pointer_cast<LM::Frontend::AST::ExprStatement>(body)) {
         // Check for fallible expressions that might propagate errors
         auto exprErrors = infer_expression_error_types(exprStmt->expression);
-        return std::find(exprErrors.begin(), exprErrors.end(), errorType) != exprErrors.end();
+        auto get_base = [](const std::string& s) {
+            size_t last_dot = s.rfind('.');
+            return (last_dot != std::string::npos) ? s.substr(last_dot + 1) : s;
+        };
+        for (const auto& err : exprErrors) {
+            if (get_base(err) == get_base(errorType)) return true;
+        }
+        return false;
     } else if (auto matchStmt = std::dynamic_pointer_cast<LM::Frontend::AST::MatchStatement>(body)) {
         for (const auto& matchCase : matchStmt->cases) {
             if (can_function_produce_error_type(matchCase.body, errorType)) {

--- a/src/frontend/type_checker/utils.cpp
+++ b/src/frontend/type_checker/utils.cpp
@@ -303,7 +303,11 @@ bool TypeChecker::is_visible(const std::string& frame_name, LM::Frontend::AST::V
     }
 
     // Check if we are inside the same frame
-    if (current_frame->name == frame_name) {
+    std::string cur_frame_name = current_frame->name;
+    if (!current_module_name.empty() && cur_frame_name.find('.') == std::string::npos) {
+        cur_frame_name = current_module_name + "." + cur_frame_name;
+    }
+    if (cur_frame_name == frame_name) {
         return true;
     }
 

--- a/std/time/datetime.lm
+++ b/std/time/datetime.lm
@@ -1,5 +1,7 @@
 // Standard Library Time DateTime Submodule
 
+pub type Time = DateTime;
+
 import std.time.duration as dur;
 import std.time.timezone as tz;
 

--- a/std/time/duration.lm
+++ b/std/time/duration.lm
@@ -1,5 +1,7 @@
 // Standard Library Time Duration Submodule
 
+pub type Duration = TimeDuration;
+
 pub fn pad_int(n: int, width: int): str {
     var s: str = "{n}";
     while (len(s) < width) {


### PR DESCRIPTION
This commit resolves various type resolution bugs in the Limitly compiler's type system that led to standard library compilation failures. It addresses import type alias/enum propagation, submodule namespace isolation/context propagation, post-opt type checking submodule skips, and name canonicalization mismatches for frame types, trait types, and method signatures.

---
*PR created automatically by Jules for task [17525394525514943552](https://jules.google.com/task/17525394525514943552) started by @netesy*